### PR TITLE
Fix delay of showing time when the page loads.

### DIFF
--- a/script.js
+++ b/script.js
@@ -79,8 +79,7 @@ window.addEventListener('DOMContentLoaded', async () => {
 
 
 // ---------------------------end of weather stuff--------------------
-
-setInterval(() => {
+function display(){
     var currentTime = new Date();
     let hours = currentTime.getHours();
     var minutes = currentTime.getMinutes();
@@ -110,7 +109,10 @@ setInterval(() => {
     var dayName = dayNames[dayOfWeek];
     document.getElementById("date").innerText = `${dayName.substring(0, 3)}, ${monthName.substring(0, 3)} ${dayOfMonth}`
     // substring(0, 3) => We are taking only three Char from the name of the month and day like Sunday > Sun
-}, 1000);
+}
+
+display(); //  To display the time when the page loads
+setInterval(display, 1000); // To update the time every second
 
 
 // Showing border or outline in when you click on searchbar
@@ -374,4 +376,3 @@ document.addEventListener("DOMContentLoaded", function () {
         }
     });
 });
-


### PR DESCRIPTION
Previously it was delaying for a second to display the time.

Now it shows when the page loads, and then shows with interval of one second.