### PR TITLE
Switched the geolocation API to `ipapi.co`

### DIFF
--- a/script.js
+++ b/script.js
@@ -29,10 +29,10 @@ window.addEventListener('DOMContentLoaded', async () => {
         const apiKey = userApiKey || defaultApiKey;
 
         // Getting current user location
-        const geoLocation = 'https://geolocation-db.com/json/';
+        const geoLocation = 'https://ipapi.co/json/';
         const locationData = await fetch(geoLocation);
         const parsedLocation = await locationData.json();
-        const currentUserLocation = parsedLocation.IPv4;
+        const currentUserLocation = parsedLocation.ip;
 
         const weatherApi = `https://api.weatherapi.com/v1/current.json?key=${apiKey}&q=${currentUserLocation}&aqi=no`;
 


### PR DESCRIPTION
This pull request addresses issue #5.

### Description:

I found that the original geolocation service ([geolocation-db.com](https://geolocation-db.com/json/)) is no longer active. Therefore, it returns unusable information, resulting in incorrect user location and weather data.

### Solution:

The solution involves replacing the original geolocation service with a new one, namely [ipapi.co](https://ipapi.co/api/).
