### PR TITLE
i18n: Improve Czech translation

### DIFF
--- a/languages.js
+++ b/languages.js
@@ -87,22 +87,22 @@ const translations = {
     "cs": {
         // Menu Itens
         "shortcutsText": "Zkratky",
-        "enableShortcutsText": "Povolit/zakázat zkratky",
-        "ai_tools_button": "Nástroje AI",
-        "enable_ai_tools": "Povolit/zakázat zkratky nástrojů AI",
-        "fahrenheitCelciusCheckbox": "Přepnout na Fahrenheit",
-        "fahrenheitCelciusText": "Obnovte stránku, abyste viděli aktualizace",
-        "WeatherApiText": "Zadejte svůj vlastní klíč WeatherAPI",
-        "WeatherApiSubtext": "Pokud funkce počasí nefunguje",
+        "enableShortcutsText": "Povolí/zakáže zkratky",
+        "ai_tools_button": "AI nástroje",
+        "enable_ai_tools": "Povolí/zakáže zkratky nástrojů AI",
+        "fahrenheitCelciusCheckbox": "Přepnout na stupně Fahrenheita",
+        "fahrenheitCelciusText": "Změny se projeví po obnovení stránky",
+        "WeatherApiText": "Zadejte svůj klíč k WeatherAPI",
+        "WeatherApiSubtext": "Pokud nefunguje funkce počasí",
         "LearnMoreButton": "Zjistit více",
-        "saveAPI": "Zadat",
+        "saveAPI": "Uložit",
         // End of Menu Itens
 
         // Body Itens
-        "conditionText": "Ahoj! Jak se máš dnes?",
-        "enterBtn": "Zadat",
-        "searchWithHint": "Hledat s",
-        "ai_tools": "Nástroje AI",
+        "conditionText": "Dobrý den! Jak se máte?",
+        "enterBtn": "Vyhledat",
+        "searchWithHint": "Vyhledávat prostřednictvím",
+        "ai_tools": "AI nástroje",
         // End of Body Itens
     }
 };


### PR DESCRIPTION
I improved Czech translation a bit. AI generated translations don't have much context (especially here I think you've not provided much of it) and generate unrelated general strings not suited to the situation, where they are used. I also localized some strings to sound more like Czech speaking (of course the meaning stayed the same).

I didn't find translation for "Double tap to edit". Could you add it, please?