### PR TITLE
Minor bug fix

### DIFF
--- a/script.js
+++ b/script.js
@@ -1704,6 +1704,7 @@ document.addEventListener("DOMContentLoaded", function () {
     loadCheckboxState("hourcheckboxState", hourcheckbox);
     loadActiveStatus("proxyinputField", proxyinputField);
     loadActiveStatus("timeformatField", timeformatField);
+    loadActiveStatus("greetingField", greetingField);
     loadActiveStatus("proxybypassField", proxybypassField);
     loadCheckboxState("adaptiveIconToggle", adaptiveIconToggle);
     loadIconStyle("iconStyle", iconStyle);


### PR DESCRIPTION
`loadActiveStatus("greetingField", greetingField);` was missing

When switching languages, the "greeting" button in settings looked editable even if it was off.