### PR TITLE
Fix issue of dark theme colors persisting even after theme change

### DIFF
--- a/script.js
+++ b/script.js
@@ -1043,8 +1043,9 @@ const resetDarkTheme = () => {
         "closeBtnX"
     ];
 
+    const safeElementById = (id) => document.getElementById(id) || null;
     resetElements.forEach((id) => {
-        const element = document.getElementById(id);
+        const element = safeElementById(id);
         if (element) {
             element.removeAttribute('style');
         }
@@ -1461,10 +1462,8 @@ colorPicker.addEventListener('input', handleColorPickerChange);
 // });
 
 
-
-
-
 // end of Function to apply the selected theme
+
 
 // ------------ Wallpaper ---------------------------------
 // Constants for database and storage


### PR DESCRIPTION
## Description
Fix: When theme switched from dark to any other, sometimes some of dark theme colors persist even after the theme has changed, requiring a page reload to fix the colors.

## Checklist
- [ ] I have read and followed the [Contributing Guidelines](../CONTRIBUTING.md).
- [ ] I have added necessary tests.
- [ ] The project builds and runs without issues.
