### PR TITLE
Fixed the Flash Issue during Reload

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,11 +19,9 @@
     <link href="./favicon/icon.ico" rel="icon" type="image/x-icon">
     <style id="iconStyle"></style>
 
+    <script src="preload.js"></script>
     <script defer src="languages.js"></script>
     <script defer src="script.js"></script>
-    <script>
-        document.documentElement.style.setProperty('--Loading-Screen-Color',localStorage.getItem('LoadingScreenColor') || "#bbd6fd");
-    </script>
 </head>
 
 <body>

--- a/index.html
+++ b/index.html
@@ -21,9 +21,16 @@
 
     <script defer src="languages.js"></script>
     <script defer src="script.js"></script>
+    <script async>
+        // This needs to be Async because this color value needs to load from local storage before loading of Page
+        document.documentElement.style.setProperty('--Loading-Screen-Color',localStorage.getItem('LoadingScreenColor') || "#bbd6fd");
+    </script>
 </head>
 
 <body>
+    <!----------------------- Loading Screen Starting ----------------------->
+    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/89/HD_transparent_picture.png/800px-HD_transparent_picture.png" id="LoadingScreen" fetchpriority="high"/>
+
     <!----------------------- ToDo List Setup Starting ----------------------->
     <!-- ToDo Icon -->
     <div class="todoListCont" id="todoListCont">

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
 
 <body>
     <!----------------------- Loading Screen Starting ----------------------->
-    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/89/HD_transparent_picture.png/800px-HD_transparent_picture.png" id="LoadingScreen" fetchpriority="high"/>
+    <img src="https://upload.wikimedia.org/wikipedia/commons/c/ca/1x1.png" id="LoadingScreen" fetchpriority="high"/>
 
     <!----------------------- ToDo List Setup Starting ----------------------->
     <!-- ToDo Icon -->

--- a/index.html
+++ b/index.html
@@ -21,8 +21,7 @@
 
     <script defer src="languages.js"></script>
     <script defer src="script.js"></script>
-    <script async>
-        // This needs to be Async because this color value needs to load from local storage before loading of Page
+    <script>
         document.documentElement.style.setProperty('--Loading-Screen-Color',localStorage.getItem('LoadingScreenColor') || "#bbd6fd");
     </script>
 </head>

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,1 @@
+document.documentElement.style.setProperty('--Loading-Screen-Color',localStorage.getItem('LoadingScreenColor') || "#bbd6fd");

--- a/script.js
+++ b/script.js
@@ -6,7 +6,6 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-
 // Check if alert has already been shown
 if (!localStorage.getItem('alertShown')) {
     // Show the alert after 4 seconds
@@ -1026,6 +1025,8 @@ document.addEventListener("DOMContentLoaded", () => {
             selectedRadioButton.checked = true;
         }
     }
+    // Remove Loading Screen When the DOM and the Theme has Loaded
+    document.getElementById('LoadingScreen').style.display = "none";
     // it is necessary for some elements not to blink when the page is reloaded
     setTimeout(() => {
         document.documentElement.classList.add('theme-transition');
@@ -1517,6 +1518,7 @@ const applySelectedTheme = (colorValue) => {
     if (faviconLink && iconPaths[colorValue]) {
         faviconLink.href = iconPaths[colorValue];
     }
+    ApplyLoadingColor();
 };
 
 // ----Color Picker || ColorPicker----
@@ -1588,6 +1590,7 @@ const applyCustomTheme = (color) => {
     document.documentElement.style.setProperty('--whitishColor-blue', '#ffffff');
     document.getElementById("rangColor").style.borderColor = color;
     document.getElementById('dfChecked').checked = false;
+    ApplyLoadingColor();
 };
 
 // Load theme on page reload// Load theme on page reload
@@ -3223,3 +3226,10 @@ document.addEventListener("DOMContentLoaded", function () {
     loadCheckboxState("fahrenheitCheckboxState", fahrenheitCheckbox);
     loadShortcuts();
 });
+
+//------------------------- LoadingScreen -----------------------//
+
+function ApplyLoadingColor(){
+    let LoadingScreenColor = getComputedStyle(document.body).getPropertyValue("background-color");
+    localStorage.setItem('LoadingScreenColor', LoadingScreenColor);
+}

--- a/style.css
+++ b/style.css
@@ -2600,3 +2600,15 @@ input:checked + .toggle:before {
 .savebtn:active {
 	transform: scale(0.96);
 }
+
+/* ---------------------- Loading Screen --------------------------- */
+#LoadingScreen {
+	background: var(--Loading-Screen-Color);
+	display: flex;
+	position: fixed;
+	height: 100%;
+	width: 100%;
+	top: 0;
+	left: 0;
+	z-index: 99999;
+}


### PR DESCRIPTION
## Description
Added a local storage item for last body background and then use that color as the color of loading screen which will result in no flashes no matter which theme you have except for the very 1st time. 


https://github.com/user-attachments/assets/19f116d5-975f-4267-b096-c1e0387fdc1b



## Related Issues
- Closes #327 
- Closes #81 
- Closes #112 

## Checklist
- [x] I have read and followed the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have added necessary tests.
- [x] The project builds and runs without issues.
