### PR TITLE
Open in new tab without switching focus

### DIFF
--- a/script.js
+++ b/script.js
@@ -568,9 +568,9 @@ document.addEventListener('DOMContentLoaded', function() {
                         // Open in a new tab
                         event.preventDefault();
                         if (isFirefox) {
-                            browser.tabs.create({ url: node.url });
+                            browser.tabs.create({ url: node.url, active: false });
                         } else if (isChrome) {
-                            chrome.tabs.create({ url: node.url });
+                            chrome.tabs.create({ url: node.url, active: false });
                         } else {
                             window.open(node.url, '_blank');
                         }


### PR DESCRIPTION
## Description
When Ctrl+Click opens a new tab, it switches focus to that new tab, now it stay on bookmarks page