### PR TITLE
No error on Live mode for bookmarks

### DIFF
--- a/script.js
+++ b/script.js
@@ -3515,34 +3515,36 @@ document.addEventListener("DOMContentLoaded", function () {
             saveCheckboxState("bookmarksCheckboxState", bookmarksCheckbox);
             return;
         }
-        if (bookmarksCheckbox.checked) {
-            bookmarksPermission.contains({
-                permissions: ['bookmarks']
-            }, function (alreadyGranted) {
-                if (alreadyGranted) {
-                    bookmarkButton.style.display = "flex";
-                    saveDisplayStatus("bookmarksDisplayStatus", "flex");
-                    saveCheckboxState("bookmarksCheckboxState", bookmarksCheckbox);
-                } else {
-                    bookmarksPermission.request({
-                        permissions: ['bookmarks']
-                    }, function (granted) {
-                        if (granted) {
-                            bookmarksAPI = chrome.bookmarks;
-                            bookmarkButton.style.display = "flex";
-                            saveDisplayStatus("bookmarksDisplayStatus", "flex");
-                            saveCheckboxState("bookmarksCheckboxState", bookmarksCheckbox);
-                        } else {
-                            bookmarksCheckbox.checked = false;
-                            saveCheckboxState("bookmarksCheckboxState", bookmarksCheckbox);
-                        }
-                    });
-                }
-            });
-        } else {
-            bookmarkButton.style.display = "none";
-            saveDisplayStatus("bookmarksDisplayStatus", "none");
-            saveCheckboxState("bookmarksCheckboxState", bookmarksCheckbox);
+        if (bookmarksPermission !== undefined) {
+            if (bookmarksCheckbox.checked) {
+                bookmarksPermission.contains({
+                    permissions: ['bookmarks']
+                }, function (alreadyGranted) {
+                    if (alreadyGranted) {
+                        bookmarkButton.style.display = "flex";
+                        saveDisplayStatus("bookmarksDisplayStatus", "flex");
+                        saveCheckboxState("bookmarksCheckboxState", bookmarksCheckbox);
+                    } else {
+                        bookmarksPermission.request({
+                            permissions: ['bookmarks']
+                        }, function (granted) {
+                            if (granted) {
+                                bookmarksAPI = chrome.bookmarks;
+                                bookmarkButton.style.display = "flex";
+                                saveDisplayStatus("bookmarksDisplayStatus", "flex");
+                                saveCheckboxState("bookmarksCheckboxState", bookmarksCheckbox);
+                            } else {
+                                bookmarksCheckbox.checked = false;
+                                saveCheckboxState("bookmarksCheckboxState", bookmarksCheckbox);
+                            }
+                        });
+                    }
+                });
+            } else {
+                bookmarkButton.style.display = "none";
+                saveDisplayStatus("bookmarksDisplayStatus", "none");
+                saveCheckboxState("bookmarksCheckboxState", bookmarksCheckbox);
+            }
         }
     });
 


### PR DESCRIPTION
## Description
Yep bookmarks still dont works, but no more this error when checking without loading as extension like live page(Github), opened in live server, open as url

![image](https://github.com/user-attachments/assets/4430604a-a4ee-4b27-a4be-c5f9f7206f2d)


View changes as `no whitespace` on

## Checklist
- [x] I have read and followed the [Contributing Guidelines](../CONTRIBUTING.md).
- [x] I have added necessary tests.
- [x] The project builds and runs without issues.
