### PR TITLE
Fix: Hide Mic Icon Visibility

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -1483,11 +1483,15 @@ if (savedState !== null) {
 
 // Set the checkbox state based on the saved or default state
 micIconCheckbox.checked = !isMicIconVisible; // Checked hides the mic icon
-micIcon.style.visibility = isMicIconVisible ? "visible" : "hidden";
+if (isMicIconVisible) {
+    micIcon.style.display = "block";  // Mic icon is displayed
+} else {
+    micIcon.style.display = "none";   // Hide the mic icon
+}
 
 // Function to toggle mic icon visibility
 function toggleMicIconVisibility(isVisible) {
-    micIcon.style.visibility = isVisible ? "visible" : "hidden";
+    micIcon.style.display = isVisible ? "block" : "none";
     localStorage.setItem("micIconVisible", isVisible); // Save to localStorage
 }
 

--- a/style.css
+++ b/style.css
@@ -1495,6 +1495,7 @@ body #bookmarkButton.bookmark-button.rotate {
 	margin-right: 10px;
 	display: flex;
 	align-items: center;
+	position: relative;
 	justify-content: center;
 	color: var(--darkColor-blue);
 	cursor: pointer;
@@ -1517,6 +1518,8 @@ body #bookmarkButton.bookmark-button.rotate {
 	height: 40px;
 	border-radius: 100%;
 	border: 2px solid transparent;
+	top: -4px;
+	left: -4px;
 }
 
 .micActive::after,


### PR DESCRIPTION
## 📝 Description
Updated the mic icon visibility logic by toggling its display property instead of using visibility. 
So now, there is more space to write a query when the mic icon is hidden, as it should be.

## 📸 Screenshots / 📹 Videos
Before:
![image](https://github.com/user-attachments/assets/ddb7b33c-3ea8-4f3f-9a0c-952214d19b74)

After:
![image](https://github.com/user-attachments/assets/4804a0ad-3643-49dd-aadb-b250fd25baca)

## 🔗 Related Issues
- Closes none
- Related to none

## ✅ Checklist
- [x] I have read and followed the [Contributing Guidelines](https://github.com/XengShi/materialYouNewTab/blob/main/CONTRIBUTING.md).
- [x] I have tested my changes by installing them as an extension (not just running via localhost) to ensure it builds, installs, and works as expected.
- [x] I have tested these changes in at least Chrome and Firefox (other browsers if applicable).
- [x] Attached visual evidence of changes (screenshots or videos) if applicable.