### PR TITLE
Fixed User Text Position

### DIFF
--- a/locales/it.js
+++ b/locales/it.js
@@ -77,7 +77,7 @@ const it = {
     "months": ['Gennaio', 'Febbraio', 'Marzo', 'Aprile', 'Maggio', 'Giugno', 'Luglio', 'Agosto', 'Settembre', 'Ottobre', 'Novembre', 'Dicembre'],
 
     // Bookmarks
-    "bookmarkHeading": "Segnalibri",
+    "bookmarksHeading": "Segnalibri",
     "bookmarkViewAs": "Visualizza come",
     "bookmarkViewGrid": "Griglia",      // Keep this shorter
     "bookmarkViewList": "Elenco",       // Keep this shorter

--- a/style.css
+++ b/style.css
@@ -1187,7 +1187,7 @@ body #bookmarkButton.bookmark-button.rotate {
 	display: block;
     word-wrap: break-word;
     max-width: 20rem;
-    max-height: 6.2rem;
+    max-height: 4.24rem;
 	overflow-x: clip;
 	overflow-y: scroll;
 	text-overflow: ellipsis;

--- a/style.css
+++ b/style.css
@@ -1172,11 +1172,11 @@ body #bookmarkButton.bookmark-button.rotate {
 
 /* ---------------------- */
 .ttteexxtt {
-	position: absolute;
+	position: relative;
 	/* background-color: yellow; */
  	/*bottom: 18px; */
 	/*Because search engines has margin-bottom 20px*/
-	bottom: 8px;
+	top: 2rem;
 	left: 10px;
  	/*text-align: center; */
 }
@@ -1184,6 +1184,14 @@ body #bookmarkButton.bookmark-button.rotate {
 #userText {
 	font-family: var(--main-font-family);
 	font-size: 1.4rem;
+	display: block;
+    word-wrap: break-word;
+    max-width: 22rem;
+    max-height: 6.4rem;
+	overflow-x: clip;
+    overflow-y: scroll;
+    text-overflow: ellipsis;
+    scrollbar-width: none;
 	margin-bottom: 10px;
 }
 
@@ -1979,6 +1987,7 @@ body #bookmarkButton.bookmark-button.rotate {
 
 	.ttteexxtt {
 		/* background-color: yellow; */
+		position: absolute;
 		height: fit-content;
 		width: fit-content;
 		bottom: 0;

--- a/style.css
+++ b/style.css
@@ -1185,9 +1185,9 @@ body #bookmarkButton.bookmark-button.rotate {
 	font-family: var(--main-font-family);
 	font-size: 1.4rem;
 	display: block;
-    word-wrap: break-word;
-    max-width: 20rem;
-    max-height: 4.24rem;
+	word-wrap: break-word;
+	max-width: 18.75rem;
+	max-height: 4.2rem;
 	overflow-x: clip;
 	overflow-y: scroll;
 	text-overflow: ellipsis;

--- a/style.css
+++ b/style.css
@@ -1186,7 +1186,7 @@ body #bookmarkButton.bookmark-button.rotate {
 	font-size: 1.4rem;
 	display: block;
     word-wrap: break-word;
-    max-width: 22rem;
+    max-width: 20rem;
     max-height: 6.4rem;
 	overflow-x: clip;
     overflow-y: scroll;

--- a/style.css
+++ b/style.css
@@ -1181,6 +1181,10 @@ body #bookmarkButton.bookmark-button.rotate {
  	/*text-align: center; */
 }
 
+#digitalClock[style="display: block;"] + .ttteexxtt {
+	top: 0;
+}
+
 #userText {
 	font-family: var(--main-font-family);
 	font-size: 1.4rem;

--- a/style.css
+++ b/style.css
@@ -1191,7 +1191,7 @@ body #bookmarkButton.bookmark-button.rotate {
 	display: block;
     word-wrap: break-word;
     max-width: 20rem;
-    max-height: 6.4rem;
+    max-height: 6.2rem;
 	overflow-x: clip;
     overflow-y: scroll;
     text-overflow: ellipsis;


### PR DESCRIPTION
## 📝 Description
- The Custom Text doesn't goes over Clock no matter what.
- Custom Text is limited to 3 lines, after that it becomes scrollable

## 📸 Screenshots / 📹 Videos
1400+
![image](https://github.com/user-attachments/assets/adf249e3-edc2-4d55-93f3-5b4238312c63)
1200+
![image](https://github.com/user-attachments/assets/79ee39a7-9aca-4242-b90f-3f11131908ac)
700+
![image](https://github.com/user-attachments/assets/4c02dead-3c87-4ca3-a315-737cacd455dc)


## 🔗 Related Issues
- Closes #437 

## ✅ Checklist
- [x] I have read and followed the [Contributing Guidelines](https://github.com/XengShi/materialYouNewTab/blob/main/CONTRIBUTING.md).
- [x] I have tested my changes by installing them as an extension (not just running via localhost) to ensure it builds, installs, and works as expected.
- [x] I have tested these changes in at least Chrome and Firefox (other browsers if applicable).
- [x] Attached visual evidence of changes (screenshots or videos) if applicable.