### PR TITLE
Updated Adaptive Icon css for Better Favicon Visibility

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -2818,8 +2818,8 @@ document.addEventListener("DOMContentLoaded", function () {
     const ADAPTIVE_ICON_CSS = `.shortcutsContainer .shortcuts .shortcutLogoContainer img {
                 height: calc(100% / sqrt(2)) !important;
                 width: calc(100% / sqrt(2)) !important;
-                filter: grayscale(1) contrast(1.4);
-                mix-blend-mode: lighten;
+                filter: grayscale(1) contrast(1.5);
+                mix-blend-mode: screen;
                 }`;
 
 

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -2818,7 +2818,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const ADAPTIVE_ICON_CSS = `.shortcutsContainer .shortcuts .shortcutLogoContainer img {
                 height: calc(100% / sqrt(2)) !important;
                 width: calc(100% / sqrt(2)) !important;
-                filter: grayscale(1) contrast(1.5);
+                filter: grayscale(1);
                 mix-blend-mode: screen;
                 }`;
 


### PR DESCRIPTION
## 📝 Description
- Changed the `mix-blend-mode` property from `lighten` to `screen`, enhancing visibility, especially for `red tones` and other darker colors.
- Adjusted the contrast to ensure consistency with the new blend mode. 

## 📸 Screenshots / 📹 Videos
Before:
![image](https://github.com/user-attachments/assets/bf3a7c84-a798-4d38-9ff4-e2dced962f3c)

After:
![image](https://github.com/user-attachments/assets/68cdb716-251d-43f7-aa06-0c26408f1403)


## 🔗 Related Issues
NA

## ✅ Checklist
- [x] I have read and followed the [Contributing Guidelines](https://github.com/XengShi/materialYouNewTab/blob/main/CONTRIBUTING.md).
- [x] I have tested my changes by installing them as an extension (not just running via localhost) to ensure it builds, installs, and works as expected.
- [x] I have tested these changes in at least Chrome and Firefox (other browsers if applicable).
- [x] Attached visual evidence of changes (screenshots or videos) if applicable.
