### PR TITLE
Fixed Shortcuts Title Overflow

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -1663,7 +1663,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
         const name = document.createElement("span");
         name.className = "shortcut-name"
-        name.textContent = shortcutName;
+        name.textContent = shortcutName.slice(0, 12) + ((shortcutName.length > 12) ? "..." : "");
 
         let icon = getCustomLogo(shortcutUrl);
 

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -1663,7 +1663,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
         const name = document.createElement("span");
         name.className = "shortcut-name"
-        name.textContent = shortcutName.slice(0, 12) + ((shortcutName.length > 12) ? "..." : "");
+        name.textContent = shortcutName;
 
         let icon = getCustomLogo(shortcutUrl);
 

--- a/style.css
+++ b/style.css
@@ -1832,6 +1832,9 @@ body #bookmarkButton.bookmark-button.rotate {
 	transition: all 0.3s;
 	font-size: 1rem;
 	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 120px;
 }
 
 .shortcuts:hover .shortcut-name {

--- a/style.css
+++ b/style.css
@@ -1832,9 +1832,6 @@ body #bookmarkButton.bookmark-button.rotate {
 	transition: all 0.3s;
 	font-size: 1rem;
 	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	max-width: 120px;
 }
 
 .shortcuts:hover .shortcut-name {


### PR DESCRIPTION
## 📝 Description
- Just Fixed the Shortcuts overflowing

## 📸 Screenshots / 📹 Videos
![image](https://github.com/user-attachments/assets/c9477640-8dd6-449c-ad00-adada4e7395f)
- After changing "New Shortcut" to "New Shortcut link"
![image](https://github.com/user-attachments/assets/9a84ef7f-c7ab-42ed-a48e-220359ffbe6b)



## 🔗 Related Issues
- None

## ✅ Checklist
- [x] I have read and followed the [Contributing Guidelines](https://github.com/XengShi/materialYouNewTab/blob/main/CONTRIBUTING.md).
- [x] I have tested my changes by installing them as an extension (not just running via localhost) to ensure it builds, installs, and works as expected.
- [x] I have tested these changes in at least Chrome and Firefox (other browsers if applicable).
- [x] Attached visual evidence of changes (screenshots or videos) if applicable.
