### PR TITLE
Added more feature in "Dark Mode".  i.e. Scheduling Dark Mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -1033,7 +1033,7 @@
                                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"
                                         style="transform: scale(1.1); transform-origin: center;">
                                         <path
-                                            d="M12 21q-.425 0-.712-.288T11 20v-4q0-.425.288-.712T12 15t.713.288T13 16v1h7q.425 0 .713.288T21 18t-.288.713T20 19h-7v1q0 .425-.288.713T12 21m-8-2q-.425 0-.712-.288T3 18t.288-.712T4 17h4q.425 0 .713.288T9 18t-.288.713T8 19zm4-4q-.425 0-.712-.288T7 14v-1H4q-.425 0-.712-.288T3 12t.288-.712T4 11h3v-1q0-.425.288-.712T8 9t.713.288T9 10v4q0 .425-.288.713T8 15m4-2q-.425 0-.712-.288T11 12t.288-.712T12 11h8q.425 0 .713.288T21 12t-.288.713T20 13zm4-4q-.425 0-.712-.288T15 8V4q0-.425.288-.712T16 3t.713.288T17 4v1h3q.425 0 .713.288T21 6t-.288.713T20 7h-3v1q0 .425-.288.713T16 9M4 7q-.425 0-.712-.288T3 6t.288-.712T4 5h8q.425 0 .713.288T13 6t-.288.713T12 7z" />
+                                            d="M12 21q-.425 0-.712-.288T11 20v-4q0-.425.288-.712T12 15t.713.288T13 16v1h7q.425 0 .713.288T21 18t-.288.713T20 19h-7v1q0 .425-.288.713T16 21m-8-2q-.425 0-.712-.288T3 18t.288-.712T4 17h4q.425 0 .713.288T9 18t-.288.713T8 19zm4-4q-.425 0-.712-.288T7 14v-1H4q-.425 0-.712-.288T3 12t.288-.712T4 11h3v-1q0-.425.288-.712T8 9t.713.288T9 10v4q0 .425-.288.713T8 15m4-2q-.425 0-.712-.288T11 12t.288-.712T12 11h8q.425 0 .713.288T21 12t-.288.713T20 13zm4-4q-.425 0-.712-.288T15 8V4q0-.425.288-.712T16 3t.713.288T17 4v1h3q.425 0 .713.288T21 6t-.288.713T20 7h-3v1q0 .425-.288.713T16 9M4 7q-.425 0-.712-.288T3 6t.288-.712T4 5h8q.425 0 .713.288T13 6t-.288.713T12 7z" />
                                     </svg>
                                 </button>
                             </label>
@@ -1185,6 +1185,20 @@
                             </div>
                             <label class="switch">
                                 <input id="enableDarkModeCheckbox" type="checkbox">
+                                <span class="toggle"></span>
+                            </label>
+                        </div>
+
+                        <!-- Add scheduled dark mode option -->
+                        <div class="ttcont" id="scheduledDarkModeField">
+                            <div class="texts">
+                                <div class="bigText" id="scheduleDarkMode">Schedule Dark Mode</div>
+                                <div class="infoText" id="scheduleDarkModeInfo">
+                                    Automatically switch dark mode based on time
+                                </div>
+                            </div>
+                            <label class="switch">
+                                <input id="scheduleDarkModeCheckbox" type="checkbox" disabled>
                                 <span class="toggle"></span>
                             </label>
                         </div>


### PR DESCRIPTION
## 📝 Description
I have made changes to automate the dark mode. Means the user can be able to schedule the dark mode as his choice.

## 📸 Screenshots / 📹 Videos
Attached is the screenshot below.

## 🔗 Related Issues
- I wish the scheduling should pop up when the user enables DAKR mode; otherwise, the scheduling option should be hidden. so it does not consume any sugar.

## ✅ Checklist
[✅] I have read and followed the [Contributing Guidelines](https://github.com/XengShi/materialYouNewTab/
blob/main/CONTRIBUTING.md).
![Screenshot 2025-01-25 191436](https://github.com/user-attachments/assets/66c12374-af7a-442c-989a-e04d58495f45)
![Screenshot 2025-01-25 191445](https://github.com/user-attachments/assets/dfbb58c1-8afc-4c99-b41c-11e517fbc51b)
[✅] I have tested my changes by installing them as an extension (not just running via localhost) to ensure it builds, installs, and works as expected.
[✅] I have tested these changes in at least Chrome and Firefox (other browsers if applicable).
[✅] Attached visual evidence of changes (screenshots or videos), if applicable.
