### PR TITLE
Better weather icons

### DIFF
--- a/scripts/weather.js
+++ b/scripts/weather.js
@@ -171,7 +171,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
                 // Setting weather Icon
                 const newWIcon = parsedData.current.condition.icon;
-                const weatherIcon = newWIcon.replace("//cdn", "https://cdn");
+                const weatherIcon = newWIcon.replace("//cdn.weatherapi.com/weather/64x64/", "https://cdn.weatherapi.com/weather/128x128/");
                 document.getElementById("wIcon").src = weatherIcon;
 
                 // Define minimum width for the slider based on the language


### PR DESCRIPTION
## 📝 Description
Using 128x128 sized weather image instead of 64x64


## 🔗 Related Issues
- Closes #532


## ✅ Checklist
- [x] I have read and followed the [Contributing Guidelines](https://github.com/XengShi/materialYouNewTab/blob/main/CONTRIBUTING.md).
- [x] I have tested my changes by installing them as an extension (not just running via localhost) to ensure it builds, installs, and works as expected.
- [x] I have tested these changes in at least Chrome and Firefox (other browsers if applicable).
- [x] Attached visual evidence of changes (screenshots or videos) if applicable.
