### PR TITLE
[Fix]Search radio button hide delay

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -517,16 +517,27 @@ document.addEventListener("DOMContentLoaded", function () {
     /* ------ Event Listeners for Searchbar dropdown ------ */
     const searchIconContainer = document.querySelectorAll(".searchIcon");
 
+    const radioButtons = document.getElementsByName("search-engine");
+
     const showEngineContainer = () => {
         searchIconContainer[1].style.display = "none";
         searchIconContainer[0].style.display = "block";
         document.getElementById("search-with-container").style.visibility = "visible";
+
+        for (const element of radioButtons) {
+            element.style.transition = "0.2s";
+        }
     }
 
     const hideEngineContainer = () => {
         searchIconContainer[0].style.display = "none";
         searchIconContainer[1].style.display = "block";
         document.getElementById("search-with-container").style.visibility = "hidden";
+
+        for (const element of radioButtons) {
+            element.style.transition = "0s";
+        }
+
     }
 
     const initShortCutSwitch = (element) => {

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -517,27 +517,16 @@ document.addEventListener("DOMContentLoaded", function () {
     /* ------ Event Listeners for Searchbar dropdown ------ */
     const searchIconContainer = document.querySelectorAll(".searchIcon");
 
-    const radioButtons = document.getElementsByName("search-engine");
-
     const showEngineContainer = () => {
         searchIconContainer[1].style.display = "none";
         searchIconContainer[0].style.display = "block";
         document.getElementById("search-with-container").style.visibility = "visible";
-
-        for (const element of radioButtons) {
-            element.style.transition = "0.2s";
-        }
     }
 
     const hideEngineContainer = () => {
         searchIconContainer[0].style.display = "none";
         searchIconContainer[1].style.display = "block";
         document.getElementById("search-with-container").style.visibility = "hidden";
-
-        for (const element of radioButtons) {
-            element.style.transition = "0s";
-        }
-
     }
 
     const initShortCutSwitch = (element) => {

--- a/style.css
+++ b/style.css
@@ -1814,7 +1814,7 @@ body #bookmarkButton.bookmark-button.rotate {
 }
 
 .theme-transition .search-engine input[type="radio"] {
-	transition: 0.2s;
+	transition: background-color 0.2s ease, border 0.2s ease;
 }
 
 /* -----------end of Radio Button Customizing------------ */

--- a/style.css
+++ b/style.css
@@ -1789,7 +1789,7 @@ body #bookmarkButton.bookmark-button.rotate {
 }
 
 .searchEnginesContainer .search-engine label {
-	margin: 0 16px 0 10px;
+	margin: 0 15px 0 10px;
 	cursor: pointer;
 }
 
@@ -1799,12 +1799,12 @@ body #bookmarkButton.bookmark-button.rotate {
 	-webkit-appearance: none;
 	-moz-appearance: none;
 	background-color: var(--whitishColor-blue);
-	width: 16px;
-	height: 16px;
+	width: 19px;
+	height: 19px;
 	border-radius: 50%;
 	border: 2px solid var(--whitishColor-blue);
 	outline: none;
-	margin-right: 8px;
+	margin-right: 7px;
 	cursor: pointer;
 	/* transition: 0.2s; */
 }

--- a/style.css
+++ b/style.css
@@ -1799,8 +1799,8 @@ body #bookmarkButton.bookmark-button.rotate {
 	-webkit-appearance: none;
 	-moz-appearance: none;
 	background-color: var(--whitishColor-blue);
-	width: 22px;
-	height: 22px;
+	width: 16px;
+	height: 16px;
 	border-radius: 50%;
 	border: 2px solid var(--whitishColor-blue);
 	outline: none;

--- a/style.css
+++ b/style.css
@@ -1789,7 +1789,7 @@ body #bookmarkButton.bookmark-button.rotate {
 }
 
 .searchEnginesContainer .search-engine label {
-	margin: 0 15px 0 10px;
+	margin: 0 16px 0 10px;
 	cursor: pointer;
 }
 
@@ -1799,8 +1799,8 @@ body #bookmarkButton.bookmark-button.rotate {
 	-webkit-appearance: none;
 	-moz-appearance: none;
 	background-color: var(--whitishColor-blue);
-	width: 19px;
-	height: 19px;
+	width: 22px;
+	height: 22px;
 	border-radius: 50%;
 	border: 2px solid var(--whitishColor-blue);
 	outline: none;

--- a/style.css
+++ b/style.css
@@ -1804,7 +1804,7 @@ body #bookmarkButton.bookmark-button.rotate {
 	border-radius: 50%;
 	border: 2px solid var(--whitishColor-blue);
 	outline: none;
-	margin-right: 7px;
+	margin-right: 8px;
 	cursor: pointer;
 	/* transition: 0.2s; */
 }


### PR DESCRIPTION
## 📝 Description

- Fixed radio button delayed animation when hiding search engines.
- Reduced radio toggle size to 16px for more cleaner UI.

## 📸 Screenshots / 📹 Videos

https://github.com/user-attachments/assets/23545d20-0dfd-4e0d-a2ae-a1af2610e076

## 🔗 Related Issues
- Closes #<issue_number>
- Related to #<issue_number> (optional)

## ✅ Checklist
- [x] I have read and followed the [Contributing Guidelines](https://github.com/XengShi/materialYouNewTab/blob/main/CONTRIBUTING.md).
- [x] I have tested my changes by installing them as an extension (not just running via localhost) to ensure it builds, installs, and works as expected.
- [x] I have tested these changes in at least Chrome and Firefox (other browsers if applicable).
- [x] Attached visual evidence of changes (screenshots or videos) if applicable.
