### PR TITLE
[Feature] Shortcut Reordering Feature to Homepage and Settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
     <script defer src="scripts/custom-text.js"></script>
     <script defer src="scripts/browser-utils.js"></script>
     <!-- <script defer src="scripts/search.js"></script> -->
+    <script defer src="scripts/sortable.js"></script>
     <script defer src="scripts/shortcuts.js"></script>
     <script defer src="scripts/script.js"></script>
     <script defer src="scripts/search-suggestions.js"></script>

--- a/scripts/ai-tools.js
+++ b/scripts/ai-tools.js
@@ -8,7 +8,7 @@
 
 // When User click on "AI-Tools"
 const aiToolName = document.getElementById("toolsCont");
-const shortcuts = document.getElementById("shortcutsContainer");
+const shortcuts = document.getElementById("shortcuts-section");
 
 function toggleShortcuts(event) {
     const shortcutsCheckbox = document.getElementById("shortcutsCheckbox");

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -517,16 +517,27 @@ document.addEventListener("DOMContentLoaded", function () {
     /* ------ Event Listeners for Searchbar dropdown ------ */
     const searchIconContainer = document.querySelectorAll(".searchIcon");
 
+    const radioButtons = document.getElementsByName("search-engine");
+
     const showEngineContainer = () => {
         searchIconContainer[1].style.display = "none";
         searchIconContainer[0].style.display = "block";
         document.getElementById("search-with-container").style.visibility = "visible";
+
+        for (const element of radioButtons) {
+            element.style.transition = "0.2s";
+        }
     }
 
     const hideEngineContainer = () => {
         searchIconContainer[0].style.display = "none";
         searchIconContainer[1].style.display = "block";
         document.getElementById("search-with-container").style.visibility = "hidden";
+
+        for (const element of radioButtons) {
+            element.style.transition = "0s";
+        }
+
     }
 
     const initShortCutSwitch = (element) => {

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -517,27 +517,16 @@ document.addEventListener("DOMContentLoaded", function () {
     /* ------ Event Listeners for Searchbar dropdown ------ */
     const searchIconContainer = document.querySelectorAll(".searchIcon");
 
-    const radioButtons = document.getElementsByName("search-engine");
-
     const showEngineContainer = () => {
         searchIconContainer[1].style.display = "none";
         searchIconContainer[0].style.display = "block";
         document.getElementById("search-with-container").style.visibility = "visible";
-
-        for (const element of radioButtons) {
-            element.style.transition = "0.2s";
-        }
     }
 
     const hideEngineContainer = () => {
         searchIconContainer[0].style.display = "none";
         searchIconContainer[1].style.display = "block";
         document.getElementById("search-with-container").style.visibility = "hidden";
-
-        for (const element of radioButtons) {
-            element.style.transition = "0s";
-        }
-
     }
 
     const initShortCutSwitch = (element) => {

--- a/scripts/shortcuts.js
+++ b/scripts/shortcuts.js
@@ -1,237 +1,339 @@
-/*
- * Material You NewTab
- * Copyright (c) 2023-2025 XengShi
- * Licensed under the GNU General Public License v3.0 (GPL-3.0)
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <https://www.gnu.org/licenses/>.
- */
+const DEFAULT_SHORTCUTS = [
+    {
+        name: "Youtube",
+        url: "youtube.com",
+        svg: "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\">\n                <circle cx=\"12\" cy=\"12\" r=\"12\" class=\"accentColor shorcutDarkColor\"/>\n                <g style=\"transform: scale(0.6); transform-origin: center;\">\n                <path class=\"bgLightTint\" id=\"darkLightTint\" fill-rule=\"evenodd\"\n                    d=\"M23.498 6.186a3.02 3.02 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.02 3.02 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.02 3.02 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.02 3.02 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814M9.545 15.568V8.432L15.818 12z\" />\n                </g>\n            </svg>"
+    },
+    {
+        name: "Gmail",
+        url: "mail.google.com",
+        svg: "<svg fill=\"none\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\">\n	            <circle cx=\"12\" cy=\"12\" r=\"12\" class=\"accentColor shorcutDarkColor\"/>\n                <g transform=\"translate(12, 12) scale(0.7) translate(-10, -10)\">\n	            <path class=\"bgLightTint\" id=\"darkLightTint\" fill-rule=\"evenodd\"\n                    d=\"m7.172 11.334l2.83 1.935l2.728-1.882l6.115 6.033q-.242.079-.512.08H1.667c-.22 0-.43-.043-.623-.12zM20 6.376v9.457c0 .247-.054.481-.15.692l-5.994-5.914zM0 6.429l6.042 4.132l-5.936 5.858A1.7 1.7 0 0 1 0 15.833zM18.333 2.5c.92 0 1.667.746 1.667 1.667v.586L9.998 11.648L0 4.81v-.643C0 3.247.746 2.5 1.667 2.5z\" />\n                </g>\n            </svg>"
+    },
+    {
+        name: "Telegram",
+        url: "web.telegram.org",
+        svg: "<svg fill=\"none\" height=\"20\" viewBox=\"0 0 20 20\" width=\"20\" xmlns=\"http://www.w3.org/2000/svg\">\n                <path class=\"accentColor shorcutDarkColor\"\n                    d=\"M10 0C4.48 0 0 4.48 0 10C0 15.52 4.48 20 10 20C15.52 20 20 15.52 20 10C20 4.48 15.52 0 10 0ZM14.64 6.8C14.49 8.38 13.84 12.22 13.51 13.99C13.37 14.74 13.09 14.99 12.83 15.02C12.25 15.07 11.81 14.64 11.25 14.27C10.37 13.69 9.87 13.33 9.02 12.77C8.03 12.12 8.67 11.76 9.24 11.18C9.39 11.03 11.95 8.7 12 8.49C12.0069 8.45819 12.006 8.42517 11.9973 8.3938C11.9886 8.36244 11.9724 8.33367 11.95 8.31C11.89 8.26 11.81 8.28 11.74 8.29C11.65 8.31 10.25 9.24 7.52 11.08C7.12 11.35 6.76 11.49 6.44 11.48C6.08 11.47 5.4 11.28 4.89 11.11C4.26 10.91 3.77 10.8 3.81 10.45C3.83 10.27 4.08 10.09 4.55 9.9C7.47 8.63 9.41 7.79 10.38 7.39C13.16 6.23 13.73 6.03 14.11 6.03C14.19 6.03 14.38 6.05 14.5 6.15C14.6 6.23 14.63 6.34 14.64 6.42C14.63 6.48 14.65 6.66 14.64 6.8Z\"\n                    fill=\"#617859\"/>\n            </svg>"
+    },
+    {
+        name: "Whatsapp",
+        url: "web.whatsapp.com",
+        svg: "<svg fill=\"none\" height=\"20\" viewBox=\"0 0 20 20\" width=\"20\" xmlns=\"http://www.w3.org/2000/svg\">\n                <path class=\"accentColor shorcutDarkColor\"\n                    d=\"M10 0C15.523 0 20 4.477 20 10C20 15.523 15.523 20 10 20C8.23279 20.0029 6.49667 19.5352 4.97001 18.645L0.00401407 20L1.35601 15.032C0.465107 13.5049 -0.00293838 11.768 1.38802e-05 10C1.38802e-05 4.477 4.47701 0 10 0ZM6.59201 5.3L6.39201 5.308C6.26254 5.31589 6.13599 5.3499 6.02001 5.408C5.91153 5.46943 5.81251 5.54622 5.72601 5.636C5.60601 5.749 5.53801 5.847 5.46501 5.942C5.09514 6.4229 4.89599 7.01331 4.89901 7.62C4.90101 8.11 5.02901 8.587 5.22901 9.033C5.63801 9.935 6.31101 10.89 7.19901 11.775C7.41301 11.988 7.62301 12.202 7.84901 12.401C8.9524 13.3725 10.2673 14.073 11.689 14.447L12.257 14.534C12.442 14.544 12.627 14.53 12.813 14.521C13.1043 14.506 13.3886 14.4271 13.646 14.29C13.777 14.2225 13.9048 14.1491 14.029 14.07C14.029 14.07 14.072 14.042 14.154 13.98C14.289 13.88 14.372 13.809 14.484 13.692C14.567 13.606 14.639 13.505 14.694 13.39C14.772 13.227 14.85 12.916 14.882 12.657C14.906 12.459 14.899 12.351 14.896 12.284C14.892 12.177 14.803 12.066 14.706 12.019L14.124 11.758C14.124 11.758 13.254 11.379 12.722 11.137C12.6663 11.1127 12.6067 11.0988 12.546 11.096C12.4776 11.089 12.4085 11.0967 12.3433 11.1186C12.2781 11.1405 12.2183 11.1761 12.168 11.223C12.163 11.221 12.096 11.278 11.373 12.154C11.3315 12.2098 11.2744 12.2519 11.2088 12.2751C11.1433 12.2982 11.0723 12.3013 11.005 12.284C10.9399 12.2665 10.876 12.2445 10.814 12.218C10.69 12.166 10.647 12.146 10.562 12.11C9.98808 11.8595 9.4567 11.5211 8.98701 11.107C8.86101 10.997 8.74401 10.877 8.62401 10.761C8.2306 10.3842 7.88774 9.95801 7.60401 9.493L7.54501 9.398C7.50264 9.33416 7.46837 9.2653 7.44301 9.193C7.40501 9.046 7.50401 8.928 7.50401 8.928C7.50401 8.928 7.74701 8.662 7.86001 8.518C7.97001 8.378 8.06301 8.242 8.12301 8.145C8.24101 7.955 8.27801 7.76 8.21601 7.609C7.93601 6.925 7.64601 6.244 7.34801 5.568C7.28901 5.434 7.11401 5.338 6.95501 5.319C6.90101 5.313 6.84701 5.307 6.79301 5.303C6.65872 5.29633 6.52415 5.29766 6.39001 5.307L6.59101 5.299L6.59201 5.3Z\"\n                    fill=\"#617859\"/>\n            </svg>"
+    },
+    {
+        name: "Twitter",
+        url: "x.com",
+        svg: "<svg fill=\"none\" height=\"20\" viewBox=\"0 0 20 20\" width=\"20\" xmlns=\"http://www.w3.org/2000/svg\">\n                <path class=\"accentColor shorcutDarkColor\"\n                    d=\"M10 0C15.5286 0 20 4.47143 20 10C20 15.5286 15.5286 20 10 20C4.47143 20 0 15.5286 0 10C0 4.47143 4.47143 0 10 0ZM8.17143 15.2714C12.6 15.2714 15.0286 11.6 15.0286 8.41429V8.1C15.5 7.75714 15.9143 7.32857 16.2286 6.84286C15.8 7.02857 15.3286 7.15714 14.8429 7.22857C15.3429 6.92857 15.7286 6.45714 15.9 5.9C15.4286 6.17143 14.9143 6.37143 14.3714 6.48571C13.9286 6.01429 13.3 5.72857 12.6143 5.72857C11.2857 5.72857 10.2 6.81429 10.2 8.14286C10.2 8.32857 10.2143 8.51429 10.2714 8.68571C8.27143 8.58571 6.48571 7.62857 5.3 6.17143C5.1 6.52857 4.97143 6.94286 4.97143 7.38571C4.97143 8.21429 5.4 8.95714 6.04286 9.38571C5.64286 9.38571 5.27143 9.27143 4.95714 9.08571V9.11429C4.95714 10.2857 5.78571 11.2571 6.88571 11.4857C6.68571 11.5429 6.47143 11.5714 6.25714 11.5714C6.1 11.5714 5.95714 11.5571 5.8 11.5286C6.1 12.4857 7 13.1857 8.04286 13.2C7.21429 13.8429 6.17143 14.2286 5.04286 14.2286C4.84286 14.2286 4.65714 14.2286 4.47143 14.2C5.52857 14.8857 6.8 15.2857 8.15714 15.2857\"\n                    fill=\"#617859\"/>\n            </svg>"
+    },
+    {
+        name: "Discord",
+        url: "discord.com/app",
+        svg: "<svg fill=\"none\" width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" xmlns=\"http://www.w3.org/2000/svg\">\n                <circle cx=\"12\" cy=\"12\" r=\"12\" class=\"accentColor shorcutDarkColor\"/>\n                <g style=\"transform: scale(0.75); transform-origin: center;\">\n                <path class=\"bgLightTint\" id=\"darkLightTint\"\n                    d=\"M19.303 5.337A17.3 17.3 0 0 0 14.963 4c-.191.329-.403.775-.552 1.125a16.6 16.6 0 0 0-4.808 0C9.454 4.775 9.23 4.329 9.05 4a17 17 0 0 0-4.342 1.337C1.961 9.391 1.218 13.35 1.59 17.255a17.7 17.7 0 0 0 5.318 2.664a13 13 0 0 0 1.136-1.836c-.627-.234-1.22-.52-1.794-.86c.149-.106.297-.223.435-.34c3.46 1.582 7.207 1.582 10.624 0c.149.117.287.234.435.34c-.573.34-1.167.626-1.793.86a13 13 0 0 0 1.135 1.836a17.6 17.6 0 0 0 5.318-2.664c.457-4.52-.722-8.448-3.1-11.918M8.52 14.846c-1.04 0-1.889-.945-1.889-2.101s.828-2.102 1.89-2.102c1.05 0 1.91.945 1.888 2.102c0 1.156-.838 2.1-1.889 2.1m6.974 0c-1.04 0-1.89-.945-1.89-2.101s.828-2.102 1.89-2.102c1.05 0 1.91.945 1.889 2.102c0 1.156-.828 2.1-1.89 2.1\" />\n                </g>\n            </svg>"
+    }
+];
+const MAX_SHORTCUTS = 50;
+const MIN_SHORTCUTS = 1;
+const PLACEHOLDER_SHORTCUT_NAME = "New shortcut";
+const PLACEHOLDER_SHORTCUT_URL = "https://github.com/XengShi/materialYouNewTab";
 
-document.addEventListener("DOMContentLoaded", function () {
-    // Maximum number of shortcuts allowed
-    const MAX_SHORTCUTS_ALLOWED = 50;
+const GOOGLE_FAVICON_API_FALLBACK = (hostname) =>
+    `https://s2.googleusercontent.com/s2/favicons?domain_url=https://${hostname}&sz=256`;
 
-    // Minimum number of  shorcutDarkColor allowed
-    const MIN_SHORTCUTS_ALLOWED = 1;
-
-    // The new shortcut placeholder info
-    const PLACEHOLDER_SHORTCUT_NAME = "New shortcut";
-    const PLACEHOLDER_SHORTCUT_URL = "https://github.com/XengShi/materialYouNewTab";
-
-    // The placeholder for an empty shortcut
-    const SHORTCUT_NAME_PLACEHOLDER = "Shortcut Name";
-    const SHORTCUT_URL_PLACEHOLDER = "Shortcut URL";
-
-    const SHORTCUT_PRESET_NAMES = ["Youtube", "Gmail", "Telegram", "WhatsApp", "Twitter", "Discord"];
-    const SHORTCUT_PRESET_URLS_AND_LOGOS = new Map([["youtube.com", `
-            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-                <circle cx="12" cy="12" r="12" class="accentColor shorcutDarkColor"/>
-                <g style="transform: scale(0.6); transform-origin: center;">
-                <path class="bgLightTint" id="darkLightTint" fill-rule="evenodd"
-                    d="M23.498 6.186a3.02 3.02 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.02 3.02 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.02 3.02 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.02 3.02 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814M9.545 15.568V8.432L15.818 12z" />
-                </g>
-            </svg>
-            `], ["mail.google.com", `
-            <svg fill="none" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-	            <circle cx="12" cy="12" r="12" class="accentColor shorcutDarkColor"/>
-                <g transform="translate(12, 12) scale(0.7) translate(-10, -10)">
-	            <path class="bgLightTint" id="darkLightTint" fill-rule="evenodd"
-                    d="m7.172 11.334l2.83 1.935l2.728-1.882l6.115 6.033q-.242.079-.512.08H1.667c-.22 0-.43-.043-.623-.12zM20 6.376v9.457c0 .247-.054.481-.15.692l-5.994-5.914zM0 6.429l6.042 4.132l-5.936 5.858A1.7 1.7 0 0 1 0 15.833zM18.333 2.5c.92 0 1.667.746 1.667 1.667v.586L9.998 11.648L0 4.81v-.643C0 3.247.746 2.5 1.667 2.5z" />
-                </g>
-            </svg>
-            `], ["web.telegram.org", `
-            <svg fill="none" height="20" viewBox="0 0 20 20" width="20" xmlns="http://www.w3.org/2000/svg">
-                <path class="accentColor shorcutDarkColor"
-                    d="M10 0C4.48 0 0 4.48 0 10C0 15.52 4.48 20 10 20C15.52 20 20 15.52 20 10C20 4.48 15.52 0 10 0ZM14.64 6.8C14.49 8.38 13.84 12.22 13.51 13.99C13.37 14.74 13.09 14.99 12.83 15.02C12.25 15.07 11.81 14.64 11.25 14.27C10.37 13.69 9.87 13.33 9.02 12.77C8.03 12.12 8.67 11.76 9.24 11.18C9.39 11.03 11.95 8.7 12 8.49C12.0069 8.45819 12.006 8.42517 11.9973 8.3938C11.9886 8.36244 11.9724 8.33367 11.95 8.31C11.89 8.26 11.81 8.28 11.74 8.29C11.65 8.31 10.25 9.24 7.52 11.08C7.12 11.35 6.76 11.49 6.44 11.48C6.08 11.47 5.4 11.28 4.89 11.11C4.26 10.91 3.77 10.8 3.81 10.45C3.83 10.27 4.08 10.09 4.55 9.9C7.47 8.63 9.41 7.79 10.38 7.39C13.16 6.23 13.73 6.03 14.11 6.03C14.19 6.03 14.38 6.05 14.5 6.15C14.6 6.23 14.63 6.34 14.64 6.42C14.63 6.48 14.65 6.66 14.64 6.8Z"
-                    fill="#617859"/>
-            </svg>
-            `], ["web.whatsapp.com", `
-            <svg fill="none" height="20" viewBox="0 0 20 20" width="20" xmlns="http://www.w3.org/2000/svg">
-                <path class="accentColor shorcutDarkColor"
-                    d="M10 0C15.523 0 20 4.477 20 10C20 15.523 15.523 20 10 20C8.23279 20.0029 6.49667 19.5352 4.97001 18.645L0.00401407 20L1.35601 15.032C0.465107 13.5049 -0.00293838 11.768 1.38802e-05 10C1.38802e-05 4.477 4.47701 0 10 0ZM6.59201 5.3L6.39201 5.308C6.26254 5.31589 6.13599 5.3499 6.02001 5.408C5.91153 5.46943 5.81251 5.54622 5.72601 5.636C5.60601 5.749 5.53801 5.847 5.46501 5.942C5.09514 6.4229 4.89599 7.01331 4.89901 7.62C4.90101 8.11 5.02901 8.587 5.22901 9.033C5.63801 9.935 6.31101 10.89 7.19901 11.775C7.41301 11.988 7.62301 12.202 7.84901 12.401C8.9524 13.3725 10.2673 14.073 11.689 14.447L12.257 14.534C12.442 14.544 12.627 14.53 12.813 14.521C13.1043 14.506 13.3886 14.4271 13.646 14.29C13.777 14.2225 13.9048 14.1491 14.029 14.07C14.029 14.07 14.072 14.042 14.154 13.98C14.289 13.88 14.372 13.809 14.484 13.692C14.567 13.606 14.639 13.505 14.694 13.39C14.772 13.227 14.85 12.916 14.882 12.657C14.906 12.459 14.899 12.351 14.896 12.284C14.892 12.177 14.803 12.066 14.706 12.019L14.124 11.758C14.124 11.758 13.254 11.379 12.722 11.137C12.6663 11.1127 12.6067 11.0988 12.546 11.096C12.4776 11.089 12.4085 11.0967 12.3433 11.1186C12.2781 11.1405 12.2183 11.1761 12.168 11.223C12.163 11.221 12.096 11.278 11.373 12.154C11.3315 12.2098 11.2744 12.2519 11.2088 12.2751C11.1433 12.2982 11.0723 12.3013 11.005 12.284C10.9399 12.2665 10.876 12.2445 10.814 12.218C10.69 12.166 10.647 12.146 10.562 12.11C9.98808 11.8595 9.4567 11.5211 8.98701 11.107C8.86101 10.997 8.74401 10.877 8.62401 10.761C8.2306 10.3842 7.88774 9.95801 7.60401 9.493L7.54501 9.398C7.50264 9.33416 7.46837 9.2653 7.44301 9.193C7.40501 9.046 7.50401 8.928 7.50401 8.928C7.50401 8.928 7.74701 8.662 7.86001 8.518C7.97001 8.378 8.06301 8.242 8.12301 8.145C8.24101 7.955 8.27801 7.76 8.21601 7.609C7.93601 6.925 7.64601 6.244 7.34801 5.568C7.28901 5.434 7.11401 5.338 6.95501 5.319C6.90101 5.313 6.84701 5.307 6.79301 5.303C6.65872 5.29633 6.52415 5.29766 6.39001 5.307L6.59101 5.299L6.59201 5.3Z"
-                    fill="#617859"/>
-            </svg>
-            `], ["x.com", `
-            <svg fill="none" height="20" viewBox="0 0 20 20" width="20" xmlns="http://www.w3.org/2000/svg">
-                <path class="accentColor shorcutDarkColor"
-                    d="M10 0C15.5286 0 20 4.47143 20 10C20 15.5286 15.5286 20 10 20C4.47143 20 0 15.5286 0 10C0 4.47143 4.47143 0 10 0ZM8.17143 15.2714C12.6 15.2714 15.0286 11.6 15.0286 8.41429V8.1C15.5 7.75714 15.9143 7.32857 16.2286 6.84286C15.8 7.02857 15.3286 7.15714 14.8429 7.22857C15.3429 6.92857 15.7286 6.45714 15.9 5.9C15.4286 6.17143 14.9143 6.37143 14.3714 6.48571C13.9286 6.01429 13.3 5.72857 12.6143 5.72857C11.2857 5.72857 10.2 6.81429 10.2 8.14286C10.2 8.32857 10.2143 8.51429 10.2714 8.68571C8.27143 8.58571 6.48571 7.62857 5.3 6.17143C5.1 6.52857 4.97143 6.94286 4.97143 7.38571C4.97143 8.21429 5.4 8.95714 6.04286 9.38571C5.64286 9.38571 5.27143 9.27143 4.95714 9.08571V9.11429C4.95714 10.2857 5.78571 11.2571 6.88571 11.4857C6.68571 11.5429 6.47143 11.5714 6.25714 11.5714C6.1 11.5714 5.95714 11.5571 5.8 11.5286C6.1 12.4857 7 13.1857 8.04286 13.2C7.21429 13.8429 6.17143 14.2286 5.04286 14.2286C4.84286 14.2286 4.65714 14.2286 4.47143 14.2C5.52857 14.8857 6.8 15.2857 8.15714 15.2857"
-                    fill="#617859"/>
-            </svg>
-            `], ["discord.com/app", `
-            <svg fill="none" width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                <circle cx="12" cy="12" r="12" class="accentColor shorcutDarkColor"/>
-                <g style="transform: scale(0.75); transform-origin: center;">
-                <path class="bgLightTint" id="darkLightTint"
-                    d="M19.303 5.337A17.3 17.3 0 0 0 14.963 4c-.191.329-.403.775-.552 1.125a16.6 16.6 0 0 0-4.808 0C9.454 4.775 9.23 4.329 9.05 4a17 17 0 0 0-4.342 1.337C1.961 9.391 1.218 13.35 1.59 17.255a17.7 17.7 0 0 0 5.318 2.664a13 13 0 0 0 1.136-1.836c-.627-.234-1.22-.52-1.794-.86c.149-.106.297-.223.435-.34c3.46 1.582 7.207 1.582 10.624 0c.149.117.287.234.435.34c-.573.34-1.167.626-1.793.86a13 13 0 0 0 1.135 1.836a17.6 17.6 0 0 0 5.318-2.664c.457-4.52-.722-8.448-3.1-11.918M8.52 14.846c-1.04 0-1.889-.945-1.889-2.101s.828-2.102 1.89-2.102c1.05 0 1.91.945 1.888 2.102c0 1.156-.838 2.1-1.889 2.1m6.974 0c-1.04 0-1.89-.945-1.89-2.101s.828-2.102 1.89-2.102c1.05 0 1.91.945 1.889 2.102c0 1.156-.828 2.1-1.89 2.1" />
-                </g>
-            </svg>
-            `]]);
-
-    const SHORTCUT_DELETE_BUTTON_HTML = `
-            <button>
-                <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px">
-                    <path d="M312-144q-29.7 0-50.85-21.15Q240-186.3 240-216v-480h-12q-15.3 0-25.65-10.29Q192-716.58 192-731.79t10.35-25.71Q212.7-768 228-768h156v-12q0-15.3 10.35-25.65Q404.7-816 420-816h120q15.3 0 25.65 10.35Q576-795.3 576-780v12h156q15.3 0 25.65 10.29Q768-747.42 768-732.21t-10.35 25.71Q747.3-696 732-696h-12v479.57Q720-186 698.85-165T648-144H312Zm336-552H312v480h336v-480ZM419.79-288q15.21 0 25.71-10.35T456-324v-264q0-15.3-10.29-25.65Q435.42-624 420.21-624t-25.71 10.35Q384-603.3 384-588v264q0 15.3 10.29 25.65Q404.58-288 419.79-288Zm120 0q15.21 0 25.71-10.35T576-324v-264q0-15.3-10.29-25.65Q555.42-624 540.21-624t-25.71 10.35Q504-603.3 504-588v264q0 15.3 10.29 25.65Q524.58-288 539.79-288ZM312-696v480-480Z"/>
-                </svg>
-            </button>
-            `;
-
-    // const FAVICON_CANDIDATES = (hostname) => [
-    //     `https://${hostname}/apple-touch-icon-180x180.png`,
-    //     `https://${hostname}/apple-touch-icon-120x120.png`,
-    //     `https://${hostname}/apple-touch-icon.png`
-    // ];
-
-    const GOOGLE_FAVICON_API_FALLBACK = (hostname) =>
-        `https://s2.googleusercontent.com/s2/favicons?domain_url=https://${hostname}&sz=256`;
-
-    // const FAVICON_REQUEST_TIMEOUT = 5000;
-
-    const ADAPTIVE_ICON_CSS = `.shortcutsContainer .shortcuts .shortcutLogoContainer img {
+const ADAPTIVE_ICON_CSS = `.shortcutsContainer .shortcuts .shortcutLogoContainer img {
                 height: calc(100% / sqrt(2)) !important;
                 width: calc(100% / sqrt(2)) !important;
                 filter: grayscale(1);
                 mix-blend-mode: screen;
                 }`;
 
-    /* ------ Element selectors ------ */
+// List used in Settings
+const shortcutListElement = document.getElementById("shortcutList");
+// List used in HomePage
+const homePageShortcutListElement = document.getElementById("shortcutsContainer");
 
-    const shortcuts = document.getElementById("shortcuts-section");
-    const shortcutsCheckbox = document.getElementById("shortcutsCheckbox");
-    const shortcutEditField = document.getElementById("shortcutEditField");
-    const adaptiveIconField = document.getElementById("adaptiveIconField");
-    const adaptiveIconToggle = document.getElementById("adaptiveIconToggle");
-    const shortcutSettingsContainer = document.getElementById("shortcutList"); // shortcuts in settings
-    const shortcutsContainer = document.getElementById("shortcutsContainer"); // shortcuts in page
-    const newShortcutButton = document.getElementById("newShortcutButton");
-    const resetShortcutsButton = document.getElementById("resetButton");
-    const iconStyle = document.getElementById("iconStyle");
+const shortcutSection = document.getElementById("shortcuts-section");
+const shortcutsCheckbox = document.getElementById("shortcutsCheckbox");
+const shortcutEditField = document.getElementById("shortcutEditField");
+const adaptiveIconField = document.getElementById("adaptiveIconField");
+const adaptiveIconToggle = document.getElementById("adaptiveIconToggle");
+const iconStyle = document.getElementById("iconStyle");
+const newShortcutButton = document.getElementById("newShortcutButton");
+const resetButton = document.getElementById("resetButton");
 
-    // const flexMonitor = document.getElementById("flexMonitor"); // monitors whether shortcuts have flex-wrap flexed
-    // const defaultHeight = document.getElementById("defaultMonitor").clientHeight; // used to compare to previous element
+// On DOM Load
+document.addEventListener("DOMContentLoaded", () => {
 
-    /* ------ Loading shortcuts ------ */
-    /**
-     * Function to load and apply all shortcut names and URLs from localStorage
-     *
-     * Iterates through the stored shortcuts and replaces the settings entry for the preset shortcuts with the
-     * stored ones.
-     * It then calls apply for all the shortcuts, to synchronize the changes settings entries with the actual shortcut
-     * container.
-     */
-    function loadShortcuts() {
-        let amount = localStorage.getItem("shortcutAmount");
-
-        const presetAmount = SHORTCUT_PRESET_NAMES.length;
-
-        if (amount === null) { // first time opening
-            amount = presetAmount;
-            localStorage.setItem("shortcutAmount", amount.toString());
-        } else {
-            amount = parseInt(amount);
+    // Sorting, Drag n Drop and DOM manipulation is done by Sortable JS
+    // Sortable for Settings List
+    new Sortable(shortcutListElement, {
+        animation: 150,
+        ghostClass: 'dragging',
+        handle: '.shortcut-drag',
+        onEnd: () => {
+            saveShortcutList();
+            loadShortcuts();
         }
+    });
 
-        // If we are not allowed to add more shortcuts.
-        if (amount >= MAX_SHORTCUTS_ALLOWED) newShortcutButton.className = "inactive";
+    // Sortable for HomePage List
+    new Sortable(homePageShortcutListElement, {
+        animation: 150,
+        ghostClass: 'dragging',
+        onEnd: () => {
+            saveHomePageShortcutList();
+            loadShortcuts();
+        }
+    });
 
-        // If we are not allowed to delete anymore, all delete buttons should be deactivated.
-        const deleteInactive = amount <= MIN_SHORTCUTS_ALLOWED;
+    // load button states and listeners
+    loadButtonStates();
+    // Load shortcuts from storage
+    loadShortcuts();
 
-        for (let i = 0; i < amount; i++) {
+    // LOAD Shortcuts
+    function loadShortcuts() {
+        const encodedList = localStorage.getItem("shortcuts");
+        const shortcutList = JSON.parse(encodedList) ?? [];
 
-            const name = localStorage.getItem("shortcutName" + i.toString()) || SHORTCUT_PRESET_NAMES[i];
-            const url = localStorage.getItem("shortcutURL" + i.toString()) ||
-                [...SHORTCUT_PRESET_URLS_AND_LOGOS.keys()][i];
+        // Settings
+        shortcutListElement.innerHTML = '';
+        // HomePage
+        homePageShortcutListElement.innerHTML = '';
 
-            const newSettingsEntry = createShortcutSettingsEntry(name, url, deleteInactive, i);
+        if (shortcutList && shortcutList.length > 0) {
+            for (const shortcut of shortcutList) {
+                // create element for Settings and append to its parent
+                const shortcutContainerElement = createShortcutContainerElement(shortcut);
+                shortcutListElement.appendChild(shortcutContainerElement);
 
-            // Save the index for the future
-            newSettingsEntry._index = i;
+                // create element for HomePage and append to its parent
+                const homePageShortcutElement = createHomePageShortcutElement(shortcut);
+                homePageShortcutListElement.appendChild(homePageShortcutElement);
 
-            shortcutSettingsContainer.appendChild(newSettingsEntry);
-
-            applyShortcut(newSettingsEntry);
+            }
+        } else {
+            // todo : create a function for migration
+            console.log("No shortcuts found.", "Adding Default shortcuts...");
+            resetToDefaultShortcuts();
         }
     }
 
+    // DELETE Shortcut
+    function deleteShortcut(shortcutElement) {
+        shortcutElement.remove();
+        saveShortcutList();
+        loadShortcuts();
+    }
 
-    /* ------ Creating shortcut elements ------ */
-    /**
-     * Function that creates a div to be used in the shortcut edit panel of the settings.
-     *
-     * @param name The name of the shortcut
-     * @param url The URL of the shortcut
-     * @param deleteInactive Whether the delete button should be active
-     * @param i The index of the shortcut
-     * @returns {HTMLDivElement} The div to be used in the settings
-     */
-    function createShortcutSettingsEntry(name, url, deleteInactive, i) {
+    // SAVE Shortcut List to local storage
+    function saveShortcutList() {
+        try{
+            const shortcutElements = document.querySelectorAll('.shortcutSettingsEntry');
+            const shortcutList = [];
+
+            shortcutElements.forEach(element => {
+                const nameInput = element.querySelector('.shortcutName');
+                const urlInput = element.querySelector('.URL');
+                shortcutList.push({
+                    name: nameInput.value ?? PLACEHOLDER_SHORTCUT_NAME,
+                    url: urlInput.value ?? PLACEHOLDER_SHORTCUT_URL
+                });
+            });
+
+            localStorage.setItem("shortcuts", JSON.stringify(shortcutList));
+        }catch (error) {
+            console.error("Error saving Settings shortcut list:", error);
+        }
+    }
+
+    // Save HomePage Shortcut List to local storage
+    function saveHomePageShortcutList() {
+        try{
+            const shortcutElements = document.querySelectorAll('.shortcuts');
+
+            const shortcutList = Array.from(shortcutElements).map(element => ({
+                name: element.dataset.name,
+                url: element.dataset.url
+            }));
+
+            localStorage.setItem("shortcuts", JSON.stringify(shortcutList));
+        }catch (error) {
+            console.error("Error saving HomePage shortcut list:", error);
+        }
+    }
+
+    // RESET to Default
+    function resetToDefaultShortcuts() {
+        const defaultList = DEFAULT_SHORTCUTS.map(function (shortcut)  {
+            return {
+                name: shortcut.name,
+                url: shortcut.url,
+            }
+        })
+        localStorage.setItem("shortcuts", JSON.stringify(defaultList));
+        loadShortcuts();
+    }
+
+    // CREATE ShortcutList item container Element [Settings]
+    function createShortcutContainerElement(shortcut) {
+        const shortcutElement = document.createElement("div");
+        shortcutElement.className = "shortcutSettingsEntry";
+
+        // Drag element
+        const dragElement = document.createElement("div");
+        dragElement.className = "shortcut-drag";
+        dragElement.style.cursor = "drag";
+        dragElement.innerHTML = `<svg stroke="currentColor" width="18" height="18" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5">
+            <circle cy="2.5" cx="5.5" r=".75"/>
+            <circle cy="8" cx="5.5" r=".75"/>
+            <circle cy="13.5" cx="5.5" r=".75"/>
+            <circle cy="2.5" cx="10.4957" r=".75"/>
+            <circle cy="8" cx="10.4957" r=".75"/>
+            <circle cy="13.5" cx="10.4957" r=".75"/>
+        </svg>`;
+
+        // DELETE button
         const deleteButtonContainer = document.createElement("div");
         deleteButtonContainer.className = "delete";
-        deleteButtonContainer.innerHTML = SHORTCUT_DELETE_BUTTON_HTML;
+        deleteButtonContainer.innerHTML = `<button>
+            <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px">
+                <path d="M312-144q-29.7 0-50.85-21.15Q240-186.3 240-216v-480h-12q-15.3 0-25.65-10.29Q192-716.58 192-731.79t10.35-25.71Q212.7-768 228-768h156v-12q0-15.3 10.35-25.65Q404.7-816 420-816h120q15.3 0 25.65 10.35Q576-795.3 576-780v12h156q15.3 0 25.65 10.29Q768-747.42 768-732.21t-10.35 25.71Q747.3-696 732-696h-12v479.57Q720-186 698.85-165T648-144H312Zm336-552H312v480h336v-480ZM419.79-288q15.21 0 25.71-10.35T456-324v-264q0-15.3-10.29-25.65Q435.42-624 420.21-624t-25.71 10.35Q384-603.3 384-588v264q0 15.3 10.29 25.65Q404.58-288 419.79-288Zm120 0q15.21 0 25.71-10.35T576-324v-264q0-15.3-10.29-25.65Q555.42-624 540.21-624t-25.71 10.35Q504-603.3 504-588v264q0 15.3 10.29 25.65Q524.58-288 539.79-288ZM312-696v480-480Z"/>
+            </svg>
+        </button>`;
+        deleteButtonContainer.addEventListener("click", () => {
+            // Check the condition right at the moment of clicking
+            if (shortcutListElement.children.length <= MIN_SHORTCUTS) {
+                alert(`You must have at least ${MIN_SHORTCUTS} shortcut(s).`);
+                return;
+            }
 
-        const deleteButton = deleteButtonContainer.children[0];
-        if (deleteInactive) deleteButton.className = "inactive";
-        deleteButton.addEventListener(
-            "click",
-            (e) => deleteShortcut(e.target.closest(".shortcutSettingsEntry"))
-        );
+            deleteShortcut(shortcutElement);
+            console.log("Deleted shortcut");
+        });
 
-        const shortcutName = document.createElement("input");
-        shortcutName.className = "shortcutName";
-        shortcutName.placeholder = SHORTCUT_NAME_PLACEHOLDER;
-        shortcutName.value = name;
-        const shortcutUrl = document.createElement("input");
-        shortcutUrl.className = "URL";
-        shortcutUrl.placeholder = SHORTCUT_URL_PLACEHOLDER;
-        shortcutUrl.value = url;
+        // NAME Input
+        const nameInput = document.createElement("input");
+        nameInput.className = "shortcutName";
+        nameInput.placeholder = "Shortcut Name";
+        nameInput.value = shortcut.name;
 
-        attachEventListenersToInputs([shortcutName, shortcutUrl]);
+        // URL Input
+        const urlInput = document.createElement("input");
+        urlInput.className = "URL";
+        urlInput.placeholder = "Shortcut URL";
+        urlInput.value = shortcut.url;
 
-        const textDiv = document.createElement("div");
-        textDiv.append(shortcutName, shortcutUrl);
+        // attach event listeners to INPUTS
+        attachEventListenersToInputs([nameInput,urlInput]);
 
-        const entryDiv = document.createElement("div");
-        entryDiv.className = "shortcutSettingsEntry";
-        entryDiv.append(textDiv, deleteButtonContainer);
+        // DIV to display name and url in column
+        const nameAndUrlContainer = document.createElement("div");
+        nameAndUrlContainer.append(nameInput, urlInput);
 
-        entryDiv._index = i;
+        // append all element in parent shortcutElement
+        shortcutElement.append(dragElement, nameAndUrlContainer, deleteButtonContainer);
+        shortcutElement.draggable = true;
 
-        return entryDiv;
+        return shortcutElement;
     }
 
-    /**
-     * This function creates a shortcut to be used for the shortcut container on the main page.
-     *
-     * @param shortcutName The name of the shortcut
-     * @param shortcutUrl The url of the shortcut
-     * @param i The index of the shortcut
-     */
-    function createShortcutElement(shortcutName, shortcutUrl, i) {
-        const shortcut = document.createElement("a");
-        shortcut.href = shortcutUrl;
+    //
+    function createHomePageShortcutElement(shortcut){
+        const validShortcut = getValidShortcut(shortcut);
 
+        // ANCHOR
+        const shortcutAnchor = document.createElement("a");
+        shortcutAnchor.href = validShortcut.url;
+
+        // TEXT
         const name = document.createElement("span");
-        name.className = "shortcut-name"
-        name.textContent = shortcutName;
+        name.className = "shortcut-name";
+        name.textContent = validShortcut.name;
 
-        let icon = getCustomLogo(shortcutUrl);
-
-        if (!icon) { // if we had to pick the fallback, attempt to get a better image in the background.
-            icon = getFallbackFavicon(shortcutUrl);
-            // getBestIconUrl(shortcutUrl).then((iconUrl) => icon.src = iconUrl).catch();
-        }
-
+        // Icon
+        const icon = getIcon(validShortcut.url);
         const iconContainer = document.createElement("div");
         iconContainer.className = "shortcutLogoContainer";
         iconContainer.appendChild(icon);
 
-        shortcut.append(iconContainer, name);
+        shortcutAnchor.append(iconContainer,name);
 
+        // Main container to hold shortcutAnchor as child
         const shortcutContainer = document.createElement("div");
         shortcutContainer.className = "shortcuts";
-        shortcutContainer.appendChild(shortcut);
-        shortcutContainer._index = i;
+        shortcutContainer.dataset.name = shortcut.name;
+        shortcutContainer.dataset.url = shortcut.url;
+        shortcutContainer.appendChild(shortcutAnchor);
 
         return shortcutContainer;
+    }
+
+    //
+    function getIcon(url){
+        function getCustomLogo() {
+
+            // remove leading (http,www) to check if the url is in default shortcuts
+            const modifiedUrl = url.replace(/^(https?:\/\/)?(www\.)?/i, '');
+
+            const defaultShortcut = DEFAULT_SHORTCUTS.find(shortcut => shortcut.url === modifiedUrl);
+            if (!defaultShortcut) return null;
+
+            const template = document.createElement("template");
+            template.innerHTML = defaultShortcut.svg;
+            return template.content.firstElementChild;
+        }
+
+        function getFallbackIcon() {
+            const logo = document.createElement("img");
+            const hostname = new URL(url).hostname;
+
+            if (hostname === "github.com") {
+                logo.src = "./svgs/shortcuts_icons/github-shortcut.svg";
+            } else if (url === "https://xengshi.github.io/materialYouNewTab/docs/PageNotFound.html") {
+                // Special case for invalid URLs
+                logo.src = "./svgs/shortcuts_icons/invalid-url.svg";
+            } else {
+                logo.src = GOOGLE_FAVICON_API_FALLBACK(hostname);
+
+                // Handle image loading error on offline scenario
+                logo.onerror = () => {
+                    logo.src = "./svgs/shortcuts_icons/offline.svg";
+                };
+            }
+
+            return logo;
+        }
+
+        let icon = getCustomLogo();
+
+        if (!icon) { // if we had to pick the fallback, attempt to get a better image in the background.
+            icon = getFallbackIcon();
+        }
+
+        return icon;
+    }
+
+    // Return a validated SHORTCUT
+    function getValidShortcut(shortcut) {
+
+        let {url, name} = shortcut;
+
+        function isValidUrl(url) {
+            const pattern = /^(https:\/\/|http:\/\/)?(([a-zA-Z\d-]+\.)+[a-zA-Z]{2,}|(\d{1,3}\.){3}\d{1,3})(\/[^\s]*)?$/i;
+            return pattern.test(url);
+        }
+
+        if (!isValidUrl(url)) {
+            url = "https://xengshi.github.io/materialYouNewTab/docs/PageNotFound.html";
+        }
+
+        const normalizedUrl = encodeURI(
+            url.startsWith('https://') || url.startsWith('http://') ? url : 'https://' + url
+        );
+
+        return {
+            name: name,
+            url: normalizedUrl,
+        }
     }
 
     /* ------ Attaching event listeners to shortcut settings ------ */
@@ -248,313 +350,119 @@ document.addEventListener("DOMContentLoaded", function () {
      */
     function attachEventListenersToInputs(inputs) {
         inputs.forEach(input => {
-            // save and apply when done
             input.addEventListener("blur", (e) => {
-                const shortcut = e.target.closest(".shortcutSettingsEntry");
-                saveShortcut(shortcut);
-                applyShortcut(shortcut);
+                if (e.relatedTarget !== inputs[1]) {
+                    saveShortcutList();
+                    loadShortcuts();
+                }
             });
-            // select all content on click:
             input.addEventListener("focus", (e) => e.target.select());
         });
+
         inputs[0].addEventListener("keydown", (e) => {
             if (e.key === "Enter") {
-                inputs[1].focus();  // Move focus to the URL
+                e.preventDefault();
+                inputs[1].focus();
             }
         });
+
         inputs[1].addEventListener("keydown", (e) => {
             if (e.key === "Enter") {
-                e.target.blur();  // Blur the input field
+                e.preventDefault();
+                e.target.blur();
+                saveShortcutList();
+                loadShortcuts();
             }
         });
     }
 
-    /* ------ Saving and applying changes to shortcuts ------ */
-    /**
-     * This function stores a shortcut by saving its values in the settings panel to the local storage.
-     *
-     * @param shortcut The shortcut to be saved
-     */
-    function saveShortcut(shortcut) {
-        const name = shortcut.querySelector("input.shortcutName").value;
-        const url = shortcut.querySelector("input.URL").value;
+    // NEW Shortcut Button
+    newShortcutButton.addEventListener("click", () => {
 
-        localStorage.setItem("shortcutName" + shortcut._index, name);
-        localStorage.setItem("shortcutURL" + shortcut._index, url);
-    }
-
-    /**
-     * This function applies a change that has been made in the settings panel to the real shortcut in the container
-     *
-     * @param shortcut The shortcut to be applied.
-     */
-    function applyShortcut(shortcut) {
-        const shortcutName = shortcut.querySelector("input.shortcutName").value;
-        let url = shortcut.querySelector("input.URL").value.trim();
-
-        // URL validation function
-        function isValidUrl(url) {
-            const pattern = /^(https:\/\/|http:\/\/)?(([a-zA-Z\d-]+\.)+[a-zA-Z]{2,}|(\d{1,3}\.){3}\d{1,3})(\/[^\s]*)?$/i;
-            return pattern.test(url);
+        // return if MAX_SHORTCUTS limit has reached
+        if (shortcutListElement.children.length >= MAX_SHORTCUTS) {
+            console.error("Max Shortcuts allowed: ", MAX_SHORTCUTS);
+            return;
         }
 
-        // Validate URL before normalizing
-        if (!isValidUrl(url)) {
-            // alert("Invalid URL. Please enter a valid URL with http or https protocol.");
-            url = "https://xengshi.github.io/materialYouNewTab/docs/PageNotFound.html";
-        }
+        // Placeholder Shortcut Object
+        const shortCut = {
+            name: PLACEHOLDER_SHORTCUT_NAME,
+            url: PLACEHOLDER_SHORTCUT_URL
+        };
 
-        // Normalize and encode URL
-        const normalizedUrl = encodeURI(
-            url.startsWith('https://') || url.startsWith('http://') ? url : 'https://' + url
-        );
+        // create shortcut
+        const shortcutContainerElement = createShortcutContainerElement(shortCut);
 
-        const i = shortcut._index;
+        shortcutListElement.appendChild(shortcutContainerElement);
 
-        const shortcutElement = createShortcutElement(shortcutName, normalizedUrl, i);
+        // scroll down when new item is added
+        shortcutContainerElement.scrollIntoView({ behavior: "smooth", block: "end" });
 
-        if (i < shortcutsContainer.children.length) {
-            shortcutsContainer.replaceChild(shortcutElement, shortcutsContainer.children[i]);
-        } else {
-            shortcutsContainer.appendChild(shortcutElement);
-        }
-    }
-
-    /* ------ Adding, deleting, and resetting shortcuts ------ */
-    /**
-     * This function creates a new shortcut in the settings panel, then saves and applies it.
-     */
-    function newShortcut() {
-        const currentAmount = parseInt(localStorage.getItem("shortcutAmount"));
-        const newAmount = currentAmount + 1;
-
-        if (newAmount > MAX_SHORTCUTS_ALLOWED) return;
-
-        // If the delete buttons were deactivated, reactivate them.
-        if (currentAmount === MIN_SHORTCUTS_ALLOWED) {
-            shortcutSettingsContainer.querySelectorAll(".delete button.inactive")
-                .forEach(b => b.classList.remove("inactive"));
-        }
-
-        // If we have reached the max, deactivate the add button.
-        if (newAmount === MAX_SHORTCUTS_ALLOWED) newShortcutButton.className = "inactive"
-
-        // Save the new amount
-        localStorage.setItem("shortcutAmount", newAmount.toString());
-
-        // create placeholder div
-        const shortcut = createShortcutSettingsEntry(
-            PLACEHOLDER_SHORTCUT_NAME, PLACEHOLDER_SHORTCUT_URL, false, currentAmount
-        );
-
-        shortcutSettingsContainer.appendChild(shortcut);
-
-        saveShortcut(shortcut);
-        applyShortcut(shortcut);
-    }
-
-    /**
-     * This function deletes a shortcut and shifts all indices of the following shortcuts back by one.
-     *
-     * @param shortcut The shortcut to be deleted.
-     */
-    function deleteShortcut(shortcut) {
-        const newAmount = (localStorage.getItem("shortcutAmount") || 0) - 1;
-        if (newAmount < MIN_SHORTCUTS_ALLOWED) return;
-
-        const i = shortcut._index;
-
-        // If we had previously deactivated it, reactivate the add button
-        newShortcutButton.classList.remove("inactive");
-
-        // Remove the shortcut from the DOM
-        shortcut.remove();
-        shortcutsContainer.removeChild(shortcutsContainer.children[i]);
-
-        // Update localStorage by shifting all the shortcuts after the deleted one and update the index
-        for (let j = i; j < newAmount; j++) {
-            const shortcutEntry = shortcutSettingsContainer.children[j];
-            shortcutEntry._index--;
-            saveShortcut(shortcutEntry);
-        }
-
-        // Remove the last shortcut from storage, as it has now moved up
-        localStorage.removeItem("shortcutName" + (newAmount));
-        localStorage.removeItem("shortcutURL" + (newAmount));
-
-        // Disable delete buttons if minimum number reached
-        if (newAmount === MIN_SHORTCUTS_ALLOWED) {
-            shortcutSettingsContainer.querySelectorAll(".delete button")
-                .forEach(button => button.className = "inactive");
-        }
-
-        // Update the shortcutAmount in localStorage
-        localStorage.setItem("shortcutAmount", (newAmount).toString());
-    }
-
-    /**
-     * This function resets shortcuts to their original state, namely the presets.
-     *
-     * It does this by deleting all shortcut-related data, then reloading the shortcuts.
-     */
-    function resetShortcuts() {
-        for (let i = 0; i < (localStorage.getItem("shortcutAmount") || 0); i++) {
-            localStorage.removeItem("shortcutName" + i);
-            localStorage.removeItem("shortcutURL" + i);
-        }
-        shortcutSettingsContainer.innerHTML = "";
-        shortcutsContainer.innerHTML = "";
-        localStorage.removeItem("shortcutAmount");
+        saveShortcutList();
         loadShortcuts();
-    }
-
-    /* ------ Shortcut favicon handling ------ */
-    /**
-     * This function verifies whether a URL for a favicon is valid.
-     *
-     * It does this by creating an image and setting the URL as the src, as fetch would be blocked by CORS.
-     *
-     * @param urls the array of potential URLs of favicons
-     * @returns {Promise<unknown>}
-     */
-    // function filterFavicon(urls) {
-    //     return new Promise((resolve, reject) => {
-    //         let found = false;
-
-    //         for (const url of urls) {
-    //             const img = new Image();
-    //             img.referrerPolicy = "no-referrer"; // Don't send referrer data
-    //             img.src = url;
-
-    //             img.onload = () => {
-    //                 if (!found) { // Make sure to resolve only once
-    //                     found = true;
-    //                     resolve(url);
-    //                 }
-    //             };
-    //         }
-
-    //         // If none of the URLs worked after all have been tried
-    //         setTimeout(() => {
-    //             if (!found) {
-    //                 reject();
-    //             }
-    //         }, FAVICON_REQUEST_TIMEOUT);
-    //     });
-    // }
-
-    /**
-     * This function returns the url to the favicon of a website, given a URL.
-     *
-     * @param urlString The url of the website for which the favicon is requested
-     * @return {Promise<String>} Potentially the favicon url
-     */
-    // async function getBestIconUrl(urlString) {
-    //     const hostname = new URL(urlString).hostname;
-    //     try {
-    //         // Wait for filterFavicon to resolve with a valid URL
-    //         return await filterFavicon(FAVICON_CANDIDATES(hostname));
-    //     } catch (error) {
-    //         return Promise.reject();
-    //     }
-    // }
-
-    /**
-     * This function uses Google's API to immediately get a favicon,
-     * to be used while loading the real one and as a fallback.
-     *
-     * @param urlString the url of the website for which the favicon is requested
-     * @returns {HTMLImageElement} The img element representing the favicon
-     */
-    function getFallbackFavicon(urlString) {
-        const logo = document.createElement("img");
-        const hostname = new URL(urlString).hostname;
-
-        if (hostname === "github.com") {
-            logo.src = "./svgs/shortcuts_icons/github-shortcut.svg";
-        } else if (urlString === "https://xengshi.github.io/materialYouNewTab/docs/PageNotFound.html") {
-            // Special case for invalid URLs
-            logo.src = "./svgs/shortcuts_icons/invalid-url.svg";
-        } else {
-            logo.src = GOOGLE_FAVICON_API_FALLBACK(hostname);
-
-            // Handle image loading error on offline scenario
-            logo.onerror = () => {
-                logo.src = "./svgs/shortcuts_icons/offline.svg";
-            };
-        }
-
-        return logo;
-    }
-
-    /**
-     * This function returns the custom logo for the url associated with a preset shortcut.
-     *
-     * @param url The url of the shortcut.
-     * @returns {Element|null} The logo if it was found, otherwise null.
-     */
-    function getCustomLogo(url) {
-        const logoHtml = SHORTCUT_PRESET_URLS_AND_LOGOS.get(url.replace("https://", ""));
-        if (!logoHtml) return null;
-
-        const template = document.createElement("template");
-        template.innerHTML = logoHtml.trim();
-        return template.content.firstElementChild;
-    }
-
-    /* ------ Event Listeners ------ */
-    shortcutsCheckbox.addEventListener("change", function () {
-        saveCheckboxState("shortcutsCheckboxState", shortcutsCheckbox);
-        if (shortcutsCheckbox.checked) {
-            shortcuts.style.display = "flex";
-            saveDisplayStatus("shortcutsDisplayStatus", "flex");
-            shortcutEditField.classList.remove("inactive");
-            saveActiveStatus("shortcutEditField", "active");
-            adaptiveIconField.classList.remove("inactive");
-            saveActiveStatus("adaptiveIconField", "active");
-        } else {
-            shortcuts.style.display = "none";
-            saveDisplayStatus("shortcutsDisplayStatus", "none");
-            shortcutEditField.classList.add("inactive");
-            saveActiveStatus("shortcutEditField", "inactive");
-            adaptiveIconField.classList.add("inactive");
-            saveActiveStatus("adaptiveIconField", "inactive");
-        }
     });
 
-    // Load checkbox state
-    loadCheckboxState("adaptiveIconToggle", adaptiveIconToggle);
-    // Apply CSS based on initial state
-    document.head.appendChild(iconStyle);
-    iconStyle.textContent = adaptiveIconToggle.checked ? ADAPTIVE_ICON_CSS : "";
+    // RESET Shortcut Button
+    resetButton.addEventListener("click", function () {
+        resetButton.classList.add("rotate-animation");
 
-    // Add event listener for checkbox
-    adaptiveIconToggle.addEventListener("change", function () {
-        saveCheckboxState("adaptiveIconToggle", adaptiveIconToggle);
-        if (adaptiveIconToggle.checked) {
-            iconStyle.textContent = ADAPTIVE_ICON_CSS;
-        } else {
-            iconStyle.textContent = "";
-        }
-    });
+        console.log("Resetting shortcuts to default....");
+        resetToDefaultShortcuts();
 
-    newShortcutButton.addEventListener("click", () => newShortcut());
-
-    resetShortcutsButton.addEventListener("click", () => {
-        resetShortcuts();
-
-        // Animate the reset button
-        const svgElement = resetShortcutsButton.querySelector("svg");
-        svgElement.classList.toggle("rotateResetButton");
+        // Remove the class after animation completes
         setTimeout(() => {
-            svgElement.classList.remove("rotateResetButton");
-        }, 300);
+            resetButton.classList.remove("rotate-animation");
+        }, 500); // Match this with your animation duration
     });
 
-    // Load and apply the saved checkbox states and display statuses
-    loadCheckboxState("shortcutsCheckboxState", shortcutsCheckbox);
-    loadActiveStatus("shortcutEditField", shortcutEditField);
-    loadActiveStatus("adaptiveIconField", adaptiveIconField);
-    loadDisplayStatus("shortcutsDisplayStatus", shortcuts);
-    loadShortcuts();
+    function loadButtonStates(){
+        const adaptiveToggled = localStorage.getItem("adaptiveIconToggle") ?? "checked";
+
+        if(adaptiveToggled === "checked"){
+            adaptiveIconToggle.checked = true;
+        }
+
+        // Shortcut Toggle Button in Settings
+        shortcutsCheckbox.addEventListener("change", () => {
+
+            saveCheckboxState("shortcutsCheckboxState", shortcutsCheckbox);
+
+            if (shortcutsCheckbox.checked) {
+                shortcutSection.style.display = "flex";
+                saveDisplayStatus("shortcutsDisplayStatus", "flex");
+                shortcutEditField.classList.remove("inactive");
+                saveActiveStatus("shortcutEditField", "active");
+                adaptiveIconField.classList.remove("inactive");
+                saveActiveStatus("adaptiveIconField", "active");
+            } else {
+                shortcutSection.style.display = "none";
+                saveDisplayStatus("shortcutsDisplayStatus", "none");
+                shortcutEditField.classList.add("inactive");
+                saveActiveStatus("shortcutEditField", "inactive");
+                adaptiveIconField.classList.add("inactive");
+                saveActiveStatus("adaptiveIconField", "inactive");
+            }
+        });
+
+        // Load State for toggles and fields from Local Storage
+        loadCheckboxState("shortcutsCheckboxState", shortcutsCheckbox);
+        // Apply CSS based on initial state
+        document.head.appendChild(iconStyle);
+        iconStyle.textContent = adaptiveIconToggle.checked ? ADAPTIVE_ICON_CSS : "";
+
+        // Add event listener for checkbox
+        adaptiveIconToggle.addEventListener("change", function () {
+            saveCheckboxState("adaptiveIconToggle", adaptiveIconToggle);
+            if (adaptiveIconToggle.checked) {
+                iconStyle.textContent = ADAPTIVE_ICON_CSS;
+            } else {
+                iconStyle.textContent = "";
+            }
+        });
+
+        loadActiveStatus("shortcutEditField", shortcutEditField);
+        loadActiveStatus("adaptiveIconField", adaptiveIconField);
+        loadDisplayStatus("shortcutsDisplayStatus", shortcuts);
+    }
 });

--- a/scripts/sortable.js
+++ b/scripts/sortable.js
@@ -1,0 +1,1226 @@
+/*! Sortable 1.15.6 - MIT | git://github.com/SortableJS/Sortable.git */
+!function (t, e) {
+    "object" == typeof exports && "undefined" != typeof module ? module.exports = e() : "function" == typeof define && define.amd ? define(e) : (t = t || self).Sortable = e()
+}(this, function () {
+    "use strict";
+
+    function e(e, t) {
+        var n, o = Object.keys(e);
+        return Object.getOwnPropertySymbols && (n = Object.getOwnPropertySymbols(e), t && (n = n.filter(function (t) {
+            return Object.getOwnPropertyDescriptor(e, t).enumerable
+        })), o.push.apply(o, n)), o
+    }
+
+    function I(o) {
+        for (var t = 1; t < arguments.length; t++) {
+            var i = null != arguments[t] ? arguments[t] : {};
+            t % 2 ? e(Object(i), !0).forEach(function (t) {
+                var e, n;
+                e = o, t = i[n = t], n in e ? Object.defineProperty(e, n, {
+                    value: t,
+                    enumerable: !0,
+                    configurable: !0,
+                    writable: !0
+                }) : e[n] = t
+            }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(o, Object.getOwnPropertyDescriptors(i)) : e(Object(i)).forEach(function (t) {
+                Object.defineProperty(o, t, Object.getOwnPropertyDescriptor(i, t))
+            })
+        }
+        return o
+    }
+
+    function o(t) {
+        return (o = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (t) {
+            return typeof t
+        } : function (t) {
+            return t && "function" == typeof Symbol && t.constructor === Symbol && t !== Symbol.prototype ? "symbol" : typeof t
+        })(t)
+    }
+
+    function a() {
+        return (a = Object.assign || function (t) {
+            for (var e = 1; e < arguments.length; e++) {
+                var n, o = arguments[e];
+                for (n in o) Object.prototype.hasOwnProperty.call(o, n) && (t[n] = o[n])
+            }
+            return t
+        }).apply(this, arguments)
+    }
+
+    function i(t, e) {
+        if (null == t) return {};
+        var n, o = function (t, e) {
+            if (null == t) return {};
+            for (var n, o = {}, i = Object.keys(t), r = 0; r < i.length; r++) n = i[r], 0 <= e.indexOf(n) || (o[n] = t[n]);
+            return o
+        }(t, e);
+        if (Object.getOwnPropertySymbols) for (var i = Object.getOwnPropertySymbols(t), r = 0; r < i.length; r++) n = i[r], 0 <= e.indexOf(n) || Object.prototype.propertyIsEnumerable.call(t, n) && (o[n] = t[n]);
+        return o
+    }
+
+    function r(t) {
+        return function (t) {
+            if (Array.isArray(t)) return l(t)
+        }(t) || function (t) {
+            if ("undefined" != typeof Symbol && null != t[Symbol.iterator] || null != t["@@iterator"]) return Array.from(t)
+        }(t) || function (t, e) {
+            if (t) {
+                if ("string" == typeof t) return l(t, e);
+                var n = Object.prototype.toString.call(t).slice(8, -1);
+                return "Map" === (n = "Object" === n && t.constructor ? t.constructor.name : n) || "Set" === n ? Array.from(t) : "Arguments" === n || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n) ? l(t, e) : void 0
+            }
+        }(t) || function () {
+            throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.")
+        }()
+    }
+
+    function l(t, e) {
+        (null == e || e > t.length) && (e = t.length);
+        for (var n = 0, o = new Array(e); n < e; n++) o[n] = t[n];
+        return o
+    }
+
+    function t(t) {
+        if ("undefined" != typeof window && window.navigator) return !!navigator.userAgent.match(t)
+    }
+
+    var y = t(/(?:Trident.*rv[ :]?11\.|msie|iemobile|Windows Phone)/i), w = t(/Edge/i), s = t(/firefox/i),
+        u = t(/safari/i) && !t(/chrome/i) && !t(/android/i), c = t(/iP(ad|od|hone)/i),
+        n = t(/chrome/i) && t(/android/i), d = {capture: !1, passive: !1};
+
+    function h(t, e, n) {
+        t.addEventListener(e, n, !y && d)
+    }
+
+    function p(t, e, n) {
+        t.removeEventListener(e, n, !y && d)
+    }
+
+    function f(t, e) {
+        if (e && (">" === e[0] && (e = e.substring(1)), t)) try {
+            if (t.matches) return t.matches(e);
+            if (t.msMatchesSelector) return t.msMatchesSelector(e);
+            if (t.webkitMatchesSelector) return t.webkitMatchesSelector(e)
+        } catch (t) {
+            return
+        }
+    }
+
+    function g(t) {
+        return t.host && t !== document && t.host.nodeType ? t.host : t.parentNode
+    }
+
+    function P(t, e, n, o) {
+        if (t) {
+            n = n || document;
+            do {
+                if (null != e && (">" !== e[0] || t.parentNode === n) && f(t, e) || o && t === n) return t
+            } while (t !== n && (t = g(t)))
+        }
+        return null
+    }
+
+    var m, v = /\s+/g;
+
+    function k(t, e, n) {
+        var o;
+        t && e && (t.classList ? t.classList[n ? "add" : "remove"](e) : (o = (" " + t.className + " ").replace(v, " ").replace(" " + e + " ", " "), t.className = (o + (n ? " " + e : "")).replace(v, " ")))
+    }
+
+    function R(t, e, n) {
+        var o = t && t.style;
+        if (o) {
+            if (void 0 === n) return document.defaultView && document.defaultView.getComputedStyle ? n = document.defaultView.getComputedStyle(t, "") : t.currentStyle && (n = t.currentStyle), void 0 === e ? n : n[e];
+            o[e = !(e in o || -1 !== e.indexOf("webkit")) ? "-webkit-" + e : e] = n + ("string" == typeof n ? "" : "px")
+        }
+    }
+
+    function b(t, e) {
+        var n = "";
+        if ("string" == typeof t) n = t; else do {
+            var o = R(t, "transform")
+        } while (o && "none" !== o && (n = o + " " + n), !e && (t = t.parentNode));
+        var i = window.DOMMatrix || window.WebKitCSSMatrix || window.CSSMatrix || window.MSCSSMatrix;
+        return i && new i(n)
+    }
+
+    function D(t, e, n) {
+        if (t) {
+            var o = t.getElementsByTagName(e), i = 0, r = o.length;
+            if (n) for (; i < r; i++) n(o[i], i);
+            return o
+        }
+        return []
+    }
+
+    function O() {
+        var t = document.scrollingElement;
+        return t || document.documentElement
+    }
+
+    function X(t, e, n, o, i) {
+        if (t.getBoundingClientRect || t === window) {
+            var r, a, l, s, c, u,
+                d = t !== window && t.parentNode && t !== O() ? (a = (r = t.getBoundingClientRect()).top, l = r.left, s = r.bottom, c = r.right, u = r.height, r.width) : (l = a = 0, s = window.innerHeight, c = window.innerWidth, u = window.innerHeight, window.innerWidth);
+            if ((e || n) && t !== window && (i = i || t.parentNode, !y)) do {
+                if (i && i.getBoundingClientRect && ("none" !== R(i, "transform") || n && "static" !== R(i, "position"))) {
+                    var h = i.getBoundingClientRect();
+                    a -= h.top + parseInt(R(i, "border-top-width")), l -= h.left + parseInt(R(i, "border-left-width")), s = a + r.height, c = l + r.width;
+                    break
+                }
+            } while (i = i.parentNode);
+            return o && t !== window && (o = (e = b(i || t)) && e.a, t = e && e.d, e && (s = (a /= t) + (u /= t), c = (l /= o) + (d /= o))), {
+                top: a,
+                left: l,
+                bottom: s,
+                right: c,
+                width: d,
+                height: u
+            }
+        }
+    }
+
+    function Y(t, e, n) {
+        for (var o = M(t, !0), i = X(t)[e]; o;) {
+            var r = X(o)[n];
+            if (!("top" === n || "left" === n ? r <= i : i <= r)) return o;
+            if (o === O()) break;
+            o = M(o, !1)
+        }
+        return !1
+    }
+
+    function B(t, e, n, o) {
+        for (var i = 0, r = 0, a = t.children; r < a.length;) {
+            if ("none" !== a[r].style.display && a[r] !== jt.ghost && (o || a[r] !== jt.dragged) && P(a[r], n.draggable, t, !1)) {
+                if (i === e) return a[r];
+                i++
+            }
+            r++
+        }
+        return null
+    }
+
+    function F(t, e) {
+        for (var n = t.lastElementChild; n && (n === jt.ghost || "none" === R(n, "display") || e && !f(n, e));) n = n.previousElementSibling;
+        return n || null
+    }
+
+    function j(t, e) {
+        var n = 0;
+        if (!t || !t.parentNode) return -1;
+        for (; t = t.previousElementSibling;) "TEMPLATE" === t.nodeName.toUpperCase() || t === jt.clone || e && !f(t, e) || n++;
+        return n
+    }
+
+    function E(t) {
+        var e = 0, n = 0, o = O();
+        if (t) do {
+            var i = b(t), r = i.a, i = i.d
+        } while (e += t.scrollLeft * r, n += t.scrollTop * i, t !== o && (t = t.parentNode));
+        return [e, n]
+    }
+
+    function M(t, e) {
+        if (!t || !t.getBoundingClientRect) return O();
+        var n = t, o = !1;
+        do {
+            if (n.clientWidth < n.scrollWidth || n.clientHeight < n.scrollHeight) {
+                var i = R(n);
+                if (n.clientWidth < n.scrollWidth && ("auto" == i.overflowX || "scroll" == i.overflowX) || n.clientHeight < n.scrollHeight && ("auto" == i.overflowY || "scroll" == i.overflowY)) {
+                    if (!n.getBoundingClientRect || n === document.body) return O();
+                    if (o || e) return n;
+                    o = !0
+                }
+            }
+        } while (n = n.parentNode);
+        return O()
+    }
+
+    function S(t, e) {
+        return Math.round(t.top) === Math.round(e.top) && Math.round(t.left) === Math.round(e.left) && Math.round(t.height) === Math.round(e.height) && Math.round(t.width) === Math.round(e.width)
+    }
+
+    function _(e, n) {
+        return function () {
+            var t;
+            m || (1 === (t = arguments).length ? e.call(this, t[0]) : e.apply(this, t), m = setTimeout(function () {
+                m = void 0
+            }, n))
+        }
+    }
+
+    function H(t, e, n) {
+        t.scrollLeft += e, t.scrollTop += n
+    }
+
+    function C(t) {
+        var e = window.Polymer, n = window.jQuery || window.Zepto;
+        return e && e.dom ? e.dom(t).cloneNode(!0) : n ? n(t).clone(!0)[0] : t.cloneNode(!0)
+    }
+
+    function T(t, e) {
+        R(t, "position", "absolute"), R(t, "top", e.top), R(t, "left", e.left), R(t, "width", e.width), R(t, "height", e.height)
+    }
+
+    function x(t) {
+        R(t, "position", ""), R(t, "top", ""), R(t, "left", ""), R(t, "width", ""), R(t, "height", "")
+    }
+
+    function L(n, o, i) {
+        var r = {};
+        return Array.from(n.children).forEach(function (t) {
+            var e;
+            P(t, o.draggable, n, !1) && !t.animated && t !== i && (e = X(t), r.left = Math.min(null !== (t = r.left) && void 0 !== t ? t : 1 / 0, e.left), r.top = Math.min(null !== (t = r.top) && void 0 !== t ? t : 1 / 0, e.top), r.right = Math.max(null !== (t = r.right) && void 0 !== t ? t : -1 / 0, e.right), r.bottom = Math.max(null !== (t = r.bottom) && void 0 !== t ? t : -1 / 0, e.bottom))
+        }), r.width = r.right - r.left, r.height = r.bottom - r.top, r.x = r.left, r.y = r.top, r
+    }
+
+    var K = "Sortable" + (new Date).getTime();
+
+    function A() {
+        var e, o = [];
+        return {
+            captureAnimationState: function () {
+                o = [], this.options.animation && [].slice.call(this.el.children).forEach(function (t) {
+                    var e, n;
+                    "none" !== R(t, "display") && t !== jt.ghost && (o.push({
+                        target: t,
+                        rect: X(t)
+                    }), e = I({}, o[o.length - 1].rect), !t.thisAnimationDuration || (n = b(t, !0)) && (e.top -= n.f, e.left -= n.e), t.fromRect = e)
+                })
+            }, addAnimationState: function (t) {
+                o.push(t)
+            }, removeAnimationState: function (t) {
+                o.splice(function (t, e) {
+                    for (var n in t) if (t.hasOwnProperty(n)) for (var o in e) if (e.hasOwnProperty(o) && e[o] === t[n][o]) return Number(n);
+                    return -1
+                }(o, {target: t}), 1)
+            }, animateAll: function (t) {
+                var c = this;
+                if (!this.options.animation) return clearTimeout(e), void ("function" == typeof t && t());
+                var u = !1, d = 0;
+                o.forEach(function (t) {
+                    var e = 0, n = t.target, o = n.fromRect, i = X(n), r = n.prevFromRect, a = n.prevToRect, l = t.rect,
+                        s = b(n, !0);
+                    s && (i.top -= s.f, i.left -= s.e), n.toRect = i, n.thisAnimationDuration && S(r, i) && !S(o, i) && (l.top - i.top) / (l.left - i.left) == (o.top - i.top) / (o.left - i.left) && (t = l, s = r, r = a, a = c.options, e = Math.sqrt(Math.pow(s.top - t.top, 2) + Math.pow(s.left - t.left, 2)) / Math.sqrt(Math.pow(s.top - r.top, 2) + Math.pow(s.left - r.left, 2)) * a.animation), S(i, o) || (n.prevFromRect = o, n.prevToRect = i, e = e || c.options.animation, c.animate(n, l, i, e)), e && (u = !0, d = Math.max(d, e), clearTimeout(n.animationResetTimer), n.animationResetTimer = setTimeout(function () {
+                        n.animationTime = 0, n.prevFromRect = null, n.fromRect = null, n.prevToRect = null, n.thisAnimationDuration = null
+                    }, e), n.thisAnimationDuration = e)
+                }), clearTimeout(e), u ? e = setTimeout(function () {
+                    "function" == typeof t && t()
+                }, d) : "function" == typeof t && t(), o = []
+            }, animate: function (t, e, n, o) {
+                var i, r;
+                o && (R(t, "transition", ""), R(t, "transform", ""), i = (r = b(this.el)) && r.a, r = r && r.d, i = (e.left - n.left) / (i || 1), r = (e.top - n.top) / (r || 1), t.animatingX = !!i, t.animatingY = !!r, R(t, "transform", "translate3d(" + i + "px," + r + "px,0)"), this.forRepaintDummy = t.offsetWidth, R(t, "transition", "transform " + o + "ms" + (this.options.easing ? " " + this.options.easing : "")), R(t, "transform", "translate3d(0,0,0)"), "number" == typeof t.animated && clearTimeout(t.animated), t.animated = setTimeout(function () {
+                    R(t, "transition", ""), R(t, "transform", ""), t.animated = !1, t.animatingX = !1, t.animatingY = !1
+                }, o))
+            }
+        }
+    }
+
+    var N = [], W = {initializeByDefault: !0}, z = {
+        mount: function (e) {
+            for (var t in W) !W.hasOwnProperty(t) || t in e || (e[t] = W[t]);
+            N.forEach(function (t) {
+                if (t.pluginName === e.pluginName) throw "Sortable: Cannot mount plugin ".concat(e.pluginName, " more than once")
+            }), N.push(e)
+        }, pluginEvent: function (e, n, o) {
+            var t = this;
+            this.eventCanceled = !1, o.cancel = function () {
+                t.eventCanceled = !0
+            };
+            var i = e + "Global";
+            N.forEach(function (t) {
+                n[t.pluginName] && (n[t.pluginName][i] && n[t.pluginName][i](I({sortable: n}, o)), n.options[t.pluginName] && n[t.pluginName][e] && n[t.pluginName][e](I({sortable: n}, o)))
+            })
+        }, initializePlugins: function (n, o, i, t) {
+            for (var e in N.forEach(function (t) {
+                var e = t.pluginName;
+                (n.options[e] || t.initializeByDefault) && ((t = new t(n, o, n.options)).sortable = n, t.options = n.options, n[e] = t, a(i, t.defaults))
+            }), n.options) {
+                var r;
+                n.options.hasOwnProperty(e) && (void 0 !== (r = this.modifyOption(n, e, n.options[e])) && (n.options[e] = r))
+            }
+        }, getEventProperties: function (e, n) {
+            var o = {};
+            return N.forEach(function (t) {
+                "function" == typeof t.eventProperties && a(o, t.eventProperties.call(n[t.pluginName], e))
+            }), o
+        }, modifyOption: function (e, n, o) {
+            var i;
+            return N.forEach(function (t) {
+                e[t.pluginName] && t.optionListeners && "function" == typeof t.optionListeners[n] && (i = t.optionListeners[n].call(e[t.pluginName], o))
+            }), i
+        }
+    };
+
+    function G(t) {
+        var e = t.sortable, n = t.rootEl, o = t.name, i = t.targetEl, r = t.cloneEl, a = t.toEl, l = t.fromEl,
+            s = t.oldIndex, c = t.newIndex, u = t.oldDraggableIndex, d = t.newDraggableIndex, h = t.originalEvent,
+            p = t.putSortable, f = t.extraEventProperties;
+        if (e = e || n && n[K]) {
+            var g, m = e.options, t = "on" + o.charAt(0).toUpperCase() + o.substr(1);
+            !window.CustomEvent || y || w ? (g = document.createEvent("Event")).initEvent(o, !0, !0) : g = new CustomEvent(o, {
+                bubbles: !0,
+                cancelable: !0
+            }), g.to = a || n, g.from = l || n, g.item = i || n, g.clone = r, g.oldIndex = s, g.newIndex = c, g.oldDraggableIndex = u, g.newDraggableIndex = d, g.originalEvent = h, g.pullMode = p ? p.lastPutMode : void 0;
+            var v, b = I(I({}, f), z.getEventProperties(o, e));
+            for (v in b) g[v] = b[v];
+            n && n.dispatchEvent(g), m[t] && m[t].call(e, g)
+        }
+    }
+
+    function U(t, e) {
+        var n = (o = 2 < arguments.length && void 0 !== arguments[2] ? arguments[2] : {}).evt, o = i(o, q);
+        z.pluginEvent.bind(jt)(t, e, I({
+            dragEl: Z,
+            parentEl: $,
+            ghostEl: Q,
+            rootEl: J,
+            nextEl: tt,
+            lastDownEl: et,
+            cloneEl: nt,
+            cloneHidden: ot,
+            dragStarted: mt,
+            putSortable: ct,
+            activeSortable: jt.active,
+            originalEvent: n,
+            oldIndex: it,
+            oldDraggableIndex: at,
+            newIndex: rt,
+            newDraggableIndex: lt,
+            hideGhostForTarget: Xt,
+            unhideGhostForTarget: Yt,
+            cloneNowHidden: function () {
+                ot = !0
+            },
+            cloneNowShown: function () {
+                ot = !1
+            },
+            dispatchSortableEvent: function (t) {
+                V({sortable: e, name: t, originalEvent: n})
+            }
+        }, o))
+    }
+
+    var q = ["evt"];
+
+    function V(t) {
+        G(I({
+            putSortable: ct,
+            cloneEl: nt,
+            targetEl: Z,
+            rootEl: J,
+            oldIndex: it,
+            oldDraggableIndex: at,
+            newIndex: rt,
+            newDraggableIndex: lt
+        }, t))
+    }
+
+    var Z, $, Q, J, tt, et, nt, ot, it, rt, at, lt, st, ct, ut, dt, ht, pt, ft, gt, mt, vt, bt, yt, wt, Dt = !1,
+        Et = !1, St = [], _t = !1, Ct = !1, Tt = [], xt = !1, Ot = [], Mt = "undefined" != typeof document, At = c,
+        Nt = w || y ? "cssFloat" : "float", It = Mt && !n && !c && "draggable" in document.createElement("div"),
+        Pt = function () {
+            if (Mt) {
+                if (y) return !1;
+                var t = document.createElement("x");
+                return t.style.cssText = "pointer-events:auto", "auto" === t.style.pointerEvents
+            }
+        }(), kt = function (t, e) {
+            var n = R(t),
+                o = parseInt(n.width) - parseInt(n.paddingLeft) - parseInt(n.paddingRight) - parseInt(n.borderLeftWidth) - parseInt(n.borderRightWidth),
+                i = B(t, 0, e), r = B(t, 1, e), a = i && R(i), l = r && R(r),
+                s = a && parseInt(a.marginLeft) + parseInt(a.marginRight) + X(i).width,
+                t = l && parseInt(l.marginLeft) + parseInt(l.marginRight) + X(r).width;
+            if ("flex" === n.display) return "column" === n.flexDirection || "column-reverse" === n.flexDirection ? "vertical" : "horizontal";
+            if ("grid" === n.display) return n.gridTemplateColumns.split(" ").length <= 1 ? "vertical" : "horizontal";
+            if (i && a.float && "none" !== a.float) {
+                e = "left" === a.float ? "left" : "right";
+                return !r || "both" !== l.clear && l.clear !== e ? "horizontal" : "vertical"
+            }
+            return i && ("block" === a.display || "flex" === a.display || "table" === a.display || "grid" === a.display || o <= s && "none" === n[Nt] || r && "none" === n[Nt] && o < s + t) ? "vertical" : "horizontal"
+        }, Rt = function (t) {
+            function l(r, a) {
+                return function (t, e, n, o) {
+                    var i = t.options.group.name && e.options.group.name && t.options.group.name === e.options.group.name;
+                    if (null == r && (a || i)) return !0;
+                    if (null == r || !1 === r) return !1;
+                    if (a && "clone" === r) return r;
+                    if ("function" == typeof r) return l(r(t, e, n, o), a)(t, e, n, o);
+                    e = (a ? t : e).options.group.name;
+                    return !0 === r || "string" == typeof r && r === e || r.join && -1 < r.indexOf(e)
+                }
+            }
+
+            var e = {}, n = t.group;
+            n && "object" == o(n) || (n = {name: n}), e.name = n.name, e.checkPull = l(n.pull, !0), e.checkPut = l(n.put), e.revertClone = n.revertClone, t.group = e
+        }, Xt = function () {
+            !Pt && Q && R(Q, "display", "none")
+        }, Yt = function () {
+            !Pt && Q && R(Q, "display", "")
+        };
+    Mt && !n && document.addEventListener("click", function (t) {
+        if (Et) return t.preventDefault(), t.stopPropagation && t.stopPropagation(), t.stopImmediatePropagation && t.stopImmediatePropagation(), Et = !1
+    }, !0);
+
+    function Bt(t) {
+        if (Z) {
+            t = t.touches ? t.touches[0] : t;
+            var e = (i = t.clientX, r = t.clientY, St.some(function (t) {
+                var e = t[K].options.emptyInsertThreshold;
+                if (e && !F(t)) {
+                    var n = X(t), o = i >= n.left - e && i <= n.right + e, e = r >= n.top - e && r <= n.bottom + e;
+                    return o && e ? a = t : void 0
+                }
+            }), a);
+            if (e) {
+                var n, o = {};
+                for (n in t) t.hasOwnProperty(n) && (o[n] = t[n]);
+                o.target = o.rootEl = e, o.preventDefault = void 0, o.stopPropagation = void 0, e[K]._onDragOver(o)
+            }
+        }
+        var i, r, a
+    }
+
+    function Ft(t) {
+        Z && Z.parentNode[K]._isOutsideThisEl(t.target)
+    }
+
+    function jt(t, e) {
+        if (!t || !t.nodeType || 1 !== t.nodeType) throw "Sortable: `el` must be an HTMLElement, not ".concat({}.toString.call(t));
+        this.el = t, this.options = e = a({}, e), t[K] = this;
+        var n, o, i = {
+            group: null,
+            sort: !0,
+            disabled: !1,
+            store: null,
+            handle: null,
+            draggable: /^[uo]l$/i.test(t.nodeName) ? ">li" : ">*",
+            swapThreshold: 1,
+            invertSwap: !1,
+            invertedSwapThreshold: null,
+            removeCloneOnHide: !0,
+            direction: function () {
+                return kt(t, this.options)
+            },
+            ghostClass: "sortable-ghost",
+            chosenClass: "sortable-chosen",
+            dragClass: "sortable-drag",
+            ignore: "a, img",
+            filter: null,
+            preventOnFilter: !0,
+            animation: 0,
+            easing: null,
+            setData: function (t, e) {
+                t.setData("Text", e.textContent)
+            },
+            dropBubble: !1,
+            dragoverBubble: !1,
+            dataIdAttr: "data-id",
+            delay: 0,
+            delayOnTouchOnly: !1,
+            touchStartThreshold: (Number.parseInt ? Number : window).parseInt(window.devicePixelRatio, 10) || 1,
+            forceFallback: !1,
+            fallbackClass: "sortable-fallback",
+            fallbackOnBody: !1,
+            fallbackTolerance: 0,
+            fallbackOffset: {x: 0, y: 0},
+            supportPointer: !1 !== jt.supportPointer && "PointerEvent" in window && (!u || c),
+            emptyInsertThreshold: 5
+        };
+        for (n in z.initializePlugins(this, t, i), i) n in e || (e[n] = i[n]);
+        for (o in Rt(e), this) "_" === o.charAt(0) && "function" == typeof this[o] && (this[o] = this[o].bind(this));
+        this.nativeDraggable = !e.forceFallback && It, this.nativeDraggable && (this.options.touchStartThreshold = 1), e.supportPointer ? h(t, "pointerdown", this._onTapStart) : (h(t, "mousedown", this._onTapStart), h(t, "touchstart", this._onTapStart)), this.nativeDraggable && (h(t, "dragover", this), h(t, "dragenter", this)), St.push(this.el), e.store && e.store.get && this.sort(e.store.get(this) || []), a(this, A())
+    }
+
+    function Ht(t, e, n, o, i, r, a, l) {
+        var s, c, u = t[K], d = u.options.onMove;
+        return !window.CustomEvent || y || w ? (s = document.createEvent("Event")).initEvent("move", !0, !0) : s = new CustomEvent("move", {
+            bubbles: !0,
+            cancelable: !0
+        }), s.to = e, s.from = t, s.dragged = n, s.draggedRect = o, s.related = i || e, s.relatedRect = r || X(e), s.willInsertAfter = l, s.originalEvent = a, t.dispatchEvent(s), c = d ? d.call(u, s, a) : c
+    }
+
+    function Lt(t) {
+        t.draggable = !1
+    }
+
+    function Kt() {
+        xt = !1
+    }
+
+    function Wt(t) {
+        return setTimeout(t, 0)
+    }
+
+    function zt(t) {
+        return clearTimeout(t)
+    }
+
+    jt.prototype = {
+        constructor: jt, _isOutsideThisEl: function (t) {
+            this.el.contains(t) || t === this.el || (vt = null)
+        }, _getDirection: function (t, e) {
+            return "function" == typeof this.options.direction ? this.options.direction.call(this, t, e, Z) : this.options.direction
+        }, _onTapStart: function (e) {
+            if (e.cancelable) {
+                var n = this, o = this.el, t = this.options, i = t.preventOnFilter, r = e.type,
+                    a = e.touches && e.touches[0] || e.pointerType && "touch" === e.pointerType && e,
+                    l = (a || e).target,
+                    s = e.target.shadowRoot && (e.path && e.path[0] || e.composedPath && e.composedPath()[0]) || l,
+                    c = t.filter;
+                if (!function (t) {
+                    Ot.length = 0;
+                    var e = t.getElementsByTagName("input"), n = e.length;
+                    for (; n--;) {
+                        var o = e[n];
+                        o.checked && Ot.push(o)
+                    }
+                }(o), !Z && !(/mousedown|pointerdown/.test(r) && 0 !== e.button || t.disabled) && !s.isContentEditable && (this.nativeDraggable || !u || !l || "SELECT" !== l.tagName.toUpperCase()) && !((l = P(l, t.draggable, o, !1)) && l.animated || et === l)) {
+                    if (it = j(l), at = j(l, t.draggable), "function" == typeof c) {
+                        if (c.call(this, e, l, this)) return V({
+                            sortable: n,
+                            rootEl: s,
+                            name: "filter",
+                            targetEl: l,
+                            toEl: o,
+                            fromEl: o
+                        }), U("filter", n, {evt: e}), void (i && e.preventDefault())
+                    } else if (c = c && c.split(",").some(function (t) {
+                        if (t = P(s, t.trim(), o, !1)) return V({
+                            sortable: n,
+                            rootEl: t,
+                            name: "filter",
+                            targetEl: l,
+                            fromEl: o,
+                            toEl: o
+                        }), U("filter", n, {evt: e}), !0
+                    })) return void (i && e.preventDefault());
+                    t.handle && !P(s, t.handle, o, !1) || this._prepareDragStart(e, a, l)
+                }
+            }
+        }, _prepareDragStart: function (t, e, n) {
+            var o, i = this, r = i.el, a = i.options, l = r.ownerDocument;
+            n && !Z && n.parentNode === r && (o = X(n), J = r, $ = (Z = n).parentNode, tt = Z.nextSibling, et = n, st = a.group, ut = {
+                target: jt.dragged = Z,
+                clientX: (e || t).clientX,
+                clientY: (e || t).clientY
+            }, ft = ut.clientX - o.left, gt = ut.clientY - o.top, this._lastX = (e || t).clientX, this._lastY = (e || t).clientY, Z.style["will-change"] = "all", o = function () {
+                U("delayEnded", i, {evt: t}), jt.eventCanceled ? i._onDrop() : (i._disableDelayedDragEvents(), !s && i.nativeDraggable && (Z.draggable = !0), i._triggerDragStart(t, e), V({
+                    sortable: i,
+                    name: "choose",
+                    originalEvent: t
+                }), k(Z, a.chosenClass, !0))
+            }, a.ignore.split(",").forEach(function (t) {
+                D(Z, t.trim(), Lt)
+            }), h(l, "dragover", Bt), h(l, "mousemove", Bt), h(l, "touchmove", Bt), a.supportPointer ? (h(l, "pointerup", i._onDrop), this.nativeDraggable || h(l, "pointercancel", i._onDrop)) : (h(l, "mouseup", i._onDrop), h(l, "touchend", i._onDrop), h(l, "touchcancel", i._onDrop)), s && this.nativeDraggable && (this.options.touchStartThreshold = 4, Z.draggable = !0), U("delayStart", this, {evt: t}), !a.delay || a.delayOnTouchOnly && !e || this.nativeDraggable && (w || y) ? o() : jt.eventCanceled ? this._onDrop() : (a.supportPointer ? (h(l, "pointerup", i._disableDelayedDrag), h(l, "pointercancel", i._disableDelayedDrag)) : (h(l, "mouseup", i._disableDelayedDrag), h(l, "touchend", i._disableDelayedDrag), h(l, "touchcancel", i._disableDelayedDrag)), h(l, "mousemove", i._delayedDragTouchMoveHandler), h(l, "touchmove", i._delayedDragTouchMoveHandler), a.supportPointer && h(l, "pointermove", i._delayedDragTouchMoveHandler), i._dragStartTimer = setTimeout(o, a.delay)))
+        }, _delayedDragTouchMoveHandler: function (t) {
+            t = t.touches ? t.touches[0] : t;
+            Math.max(Math.abs(t.clientX - this._lastX), Math.abs(t.clientY - this._lastY)) >= Math.floor(this.options.touchStartThreshold / (this.nativeDraggable && window.devicePixelRatio || 1)) && this._disableDelayedDrag()
+        }, _disableDelayedDrag: function () {
+            Z && Lt(Z), clearTimeout(this._dragStartTimer), this._disableDelayedDragEvents()
+        }, _disableDelayedDragEvents: function () {
+            var t = this.el.ownerDocument;
+            p(t, "mouseup", this._disableDelayedDrag), p(t, "touchend", this._disableDelayedDrag), p(t, "touchcancel", this._disableDelayedDrag), p(t, "pointerup", this._disableDelayedDrag), p(t, "pointercancel", this._disableDelayedDrag), p(t, "mousemove", this._delayedDragTouchMoveHandler), p(t, "touchmove", this._delayedDragTouchMoveHandler), p(t, "pointermove", this._delayedDragTouchMoveHandler)
+        }, _triggerDragStart: function (t, e) {
+            e = e || "touch" == t.pointerType && t, !this.nativeDraggable || e ? this.options.supportPointer ? h(document, "pointermove", this._onTouchMove) : h(document, e ? "touchmove" : "mousemove", this._onTouchMove) : (h(Z, "dragend", this), h(J, "dragstart", this._onDragStart));
+            try {
+                document.selection ? Wt(function () {
+                    document.selection.empty()
+                }) : window.getSelection().removeAllRanges()
+            } catch (t) {
+            }
+        }, _dragStarted: function (t, e) {
+            var n;
+            Dt = !1, J && Z ? (U("dragStarted", this, {evt: e}), this.nativeDraggable && h(document, "dragover", Ft), n = this.options, t || k(Z, n.dragClass, !1), k(Z, n.ghostClass, !0), jt.active = this, t && this._appendGhost(), V({
+                sortable: this,
+                name: "start",
+                originalEvent: e
+            })) : this._nulling()
+        }, _emulateDragOver: function () {
+            if (dt) {
+                this._lastX = dt.clientX, this._lastY = dt.clientY, Xt();
+                for (var t = document.elementFromPoint(dt.clientX, dt.clientY), e = t; t && t.shadowRoot && (t = t.shadowRoot.elementFromPoint(dt.clientX, dt.clientY)) !== e;) e = t;
+                if (Z.parentNode[K]._isOutsideThisEl(t), e) do {
+                    if (e[K]) if (e[K]._onDragOver({
+                        clientX: dt.clientX,
+                        clientY: dt.clientY,
+                        target: t,
+                        rootEl: e
+                    }) && !this.options.dragoverBubble) break
+                } while (e = g(t = e));
+                Yt()
+            }
+        }, _onTouchMove: function (t) {
+            if (ut) {
+                var e = this.options, n = e.fallbackTolerance, o = e.fallbackOffset, i = t.touches ? t.touches[0] : t,
+                    r = Q && b(Q, !0), a = Q && r && r.a, l = Q && r && r.d, e = At && wt && E(wt),
+                    a = (i.clientX - ut.clientX + o.x) / (a || 1) + (e ? e[0] - Tt[0] : 0) / (a || 1),
+                    l = (i.clientY - ut.clientY + o.y) / (l || 1) + (e ? e[1] - Tt[1] : 0) / (l || 1);
+                if (!jt.active && !Dt) {
+                    if (n && Math.max(Math.abs(i.clientX - this._lastX), Math.abs(i.clientY - this._lastY)) < n) return;
+                    this._onDragStart(t, !0)
+                }
+                Q && (r ? (r.e += a - (ht || 0), r.f += l - (pt || 0)) : r = {
+                    a: 1,
+                    b: 0,
+                    c: 0,
+                    d: 1,
+                    e: a,
+                    f: l
+                }, r = "matrix(".concat(r.a, ",").concat(r.b, ",").concat(r.c, ",").concat(r.d, ",").concat(r.e, ",").concat(r.f, ")"), R(Q, "webkitTransform", r), R(Q, "mozTransform", r), R(Q, "msTransform", r), R(Q, "transform", r), ht = a, pt = l, dt = i), t.cancelable && t.preventDefault()
+            }
+        }, _appendGhost: function () {
+            if (!Q) {
+                var t = this.options.fallbackOnBody ? document.body : J, e = X(Z, !0, At, !0, t), n = this.options;
+                if (At) {
+                    for (wt = t; "static" === R(wt, "position") && "none" === R(wt, "transform") && wt !== document;) wt = wt.parentNode;
+                    wt !== document.body && wt !== document.documentElement ? (wt === document && (wt = O()), e.top += wt.scrollTop, e.left += wt.scrollLeft) : wt = O(), Tt = E(wt)
+                }
+                k(Q = Z.cloneNode(!0), n.ghostClass, !1), k(Q, n.fallbackClass, !0), k(Q, n.dragClass, !0), R(Q, "transition", ""), R(Q, "transform", ""), R(Q, "box-sizing", "border-box"), R(Q, "margin", 0), R(Q, "top", e.top), R(Q, "left", e.left), R(Q, "width", e.width), R(Q, "height", e.height), R(Q, "opacity", "0.8"), R(Q, "position", At ? "absolute" : "fixed"), R(Q, "zIndex", "100000"), R(Q, "pointerEvents", "none"), jt.ghost = Q, t.appendChild(Q), R(Q, "transform-origin", ft / parseInt(Q.style.width) * 100 + "% " + gt / parseInt(Q.style.height) * 100 + "%")
+            }
+        }, _onDragStart: function (t, e) {
+            var n = this, o = t.dataTransfer, i = n.options;
+            U("dragStart", this, {evt: t}), jt.eventCanceled ? this._onDrop() : (U("setupClone", this), jt.eventCanceled || ((nt = C(Z)).removeAttribute("id"), nt.draggable = !1, nt.style["will-change"] = "", this._hideClone(), k(nt, this.options.chosenClass, !1), jt.clone = nt), n.cloneId = Wt(function () {
+                U("clone", n), jt.eventCanceled || (n.options.removeCloneOnHide || J.insertBefore(nt, Z), n._hideClone(), V({
+                    sortable: n,
+                    name: "clone"
+                }))
+            }), e || k(Z, i.dragClass, !0), e ? (Et = !0, n._loopId = setInterval(n._emulateDragOver, 50)) : (p(document, "mouseup", n._onDrop), p(document, "touchend", n._onDrop), p(document, "touchcancel", n._onDrop), o && (o.effectAllowed = "move", i.setData && i.setData.call(n, o, Z)), h(document, "drop", n), R(Z, "transform", "translateZ(0)")), Dt = !0, n._dragStartId = Wt(n._dragStarted.bind(n, e, t)), h(document, "selectstart", n), mt = !0, window.getSelection().removeAllRanges(), u && R(document.body, "user-select", "none"))
+        }, _onDragOver: function (n) {
+            var o, i, r, t, e, a = this.el, l = n.target, s = this.options, c = s.group, u = jt.active, d = st === c,
+                h = s.sort, p = ct || u, f = this, g = !1;
+            if (!xt) {
+                if (void 0 !== n.preventDefault && n.cancelable && n.preventDefault(), l = P(l, s.draggable, a, !0), O("dragOver"), jt.eventCanceled) return g;
+                if (Z.contains(n.target) || l.animated && l.animatingX && l.animatingY || f._ignoreWhileAnimating === l) return A(!1);
+                if (Et = !1, u && !s.disabled && (d ? h || (i = $ !== J) : ct === this || (this.lastPutMode = st.checkPull(this, u, Z, n)) && c.checkPut(this, u, Z, n))) {
+                    if (r = "vertical" === this._getDirection(n, l), o = X(Z), O("dragOverValid"), jt.eventCanceled) return g;
+                    if (i) return $ = J, M(), this._hideClone(), O("revert"), jt.eventCanceled || (tt ? J.insertBefore(Z, tt) : J.appendChild(Z)), A(!0);
+                    var m = F(a, s.draggable);
+                    if (m && (S = n, c = r, x = X(F((E = this).el, E.options.draggable)), E = L(E.el, E.options, Q), !(c ? S.clientX > E.right + 10 || S.clientY > x.bottom && S.clientX > x.left : S.clientY > E.bottom + 10 || S.clientX > x.right && S.clientY > x.top) || m.animated)) {
+                        if (m && (t = n, e = r, C = X(B((_ = this).el, 0, _.options, !0)), _ = L(_.el, _.options, Q), e ? t.clientX < _.left - 10 || t.clientY < C.top && t.clientX < C.right : t.clientY < _.top - 10 || t.clientY < C.bottom && t.clientX < C.left)) {
+                            var v = B(a, 0, s, !0);
+                            if (v === Z) return A(!1);
+                            if (D = X(l = v), !1 !== Ht(J, a, Z, o, l, D, n, !1)) return M(), a.insertBefore(Z, v), $ = a, N(), A(!0)
+                        } else if (l.parentNode === a) {
+                            var b, y, w, D = X(l), E = Z.parentNode !== a,
+                                S = (S = Z.animated && Z.toRect || o, x = l.animated && l.toRect || D, _ = (e = r) ? S.left : S.top, t = e ? S.right : S.bottom, C = e ? S.width : S.height, v = e ? x.left : x.top, S = e ? x.right : x.bottom, x = e ? x.width : x.height, !(_ === v || t === S || _ + C / 2 === v + x / 2)),
+                                _ = r ? "top" : "left", C = Y(l, "top", "top") || Y(Z, "top", "top"),
+                                v = C ? C.scrollTop : void 0;
+                            if (vt !== l && (y = D[_], _t = !1, Ct = !S && s.invertSwap || E), 0 !== (b = function (t, e, n, o, i, r, a, l) {
+                                var s = o ? t.clientY : t.clientX, c = o ? n.height : n.width, t = o ? n.top : n.left,
+                                    o = o ? n.bottom : n.right, n = !1;
+                                if (!a) if (l && yt < c * i) {
+                                    if (_t = !_t && (1 === bt ? t + c * r / 2 < s : s < o - c * r / 2) ? !0 : _t) n = !0; else if (1 === bt ? s < t + yt : o - yt < s) return -bt
+                                } else if (t + c * (1 - i) / 2 < s && s < o - c * (1 - i) / 2) return function (t) {
+                                    return j(Z) < j(t) ? 1 : -1
+                                }(e);
+                                if ((n = n || a) && (s < t + c * r / 2 || o - c * r / 2 < s)) return t + c / 2 < s ? 1 : -1;
+                                return 0
+                            }(n, l, D, r, S ? 1 : s.swapThreshold, null == s.invertedSwapThreshold ? s.swapThreshold : s.invertedSwapThreshold, Ct, vt === l))) for (var T = j(Z); (w = $.children[T -= b]) && ("none" === R(w, "display") || w === Q);) ;
+                            if (0 === b || w === l) return A(!1);
+                            bt = b;
+                            var x = (vt = l).nextElementSibling, E = !1, S = Ht(J, a, Z, o, l, D, n, E = 1 === b);
+                            if (!1 !== S) return 1 !== S && -1 !== S || (E = 1 === S), xt = !0, setTimeout(Kt, 30), M(), E && !x ? a.appendChild(Z) : l.parentNode.insertBefore(Z, E ? x : l), C && H(C, 0, v - C.scrollTop), $ = Z.parentNode, void 0 === y || Ct || (yt = Math.abs(y - X(l)[_])), N(), A(!0)
+                        }
+                    } else {
+                        if (m === Z) return A(!1);
+                        if ((l = m && a === n.target ? m : l) && (D = X(l)), !1 !== Ht(J, a, Z, o, l, D, n, !!l)) return M(), m && m.nextSibling ? a.insertBefore(Z, m.nextSibling) : a.appendChild(Z), $ = a, N(), A(!0)
+                    }
+                    if (a.contains(Z)) return A(!1)
+                }
+                return !1
+            }
+
+            function O(t, e) {
+                U(t, f, I({
+                    evt: n,
+                    isOwner: d,
+                    axis: r ? "vertical" : "horizontal",
+                    revert: i,
+                    dragRect: o,
+                    targetRect: D,
+                    canSort: h,
+                    fromSortable: p,
+                    target: l,
+                    completed: A,
+                    onMove: function (t, e) {
+                        return Ht(J, a, Z, o, t, X(t), n, e)
+                    },
+                    changed: N
+                }, e))
+            }
+
+            function M() {
+                O("dragOverAnimationCapture"), f.captureAnimationState(), f !== p && p.captureAnimationState()
+            }
+
+            function A(t) {
+                return O("dragOverCompleted", {insertion: t}), t && (d ? u._hideClone() : u._showClone(f), f !== p && (k(Z, (ct || u).options.ghostClass, !1), k(Z, s.ghostClass, !0)), ct !== f && f !== jt.active ? ct = f : f === jt.active && ct && (ct = null), p === f && (f._ignoreWhileAnimating = l), f.animateAll(function () {
+                    O("dragOverAnimationComplete"), f._ignoreWhileAnimating = null
+                }), f !== p && (p.animateAll(), p._ignoreWhileAnimating = null)), (l === Z && !Z.animated || l === a && !l.animated) && (vt = null), s.dragoverBubble || n.rootEl || l === document || (Z.parentNode[K]._isOutsideThisEl(n.target), t || Bt(n)), !s.dragoverBubble && n.stopPropagation && n.stopPropagation(), g = !0
+            }
+
+            function N() {
+                rt = j(Z), lt = j(Z, s.draggable), V({
+                    sortable: f,
+                    name: "change",
+                    toEl: a,
+                    newIndex: rt,
+                    newDraggableIndex: lt,
+                    originalEvent: n
+                })
+            }
+        }, _ignoreWhileAnimating: null, _offMoveEvents: function () {
+            p(document, "mousemove", this._onTouchMove), p(document, "touchmove", this._onTouchMove), p(document, "pointermove", this._onTouchMove), p(document, "dragover", Bt), p(document, "mousemove", Bt), p(document, "touchmove", Bt)
+        }, _offUpEvents: function () {
+            var t = this.el.ownerDocument;
+            p(t, "mouseup", this._onDrop), p(t, "touchend", this._onDrop), p(t, "pointerup", this._onDrop), p(t, "pointercancel", this._onDrop), p(t, "touchcancel", this._onDrop), p(document, "selectstart", this)
+        }, _onDrop: function (t) {
+            var e = this.el, n = this.options;
+            rt = j(Z), lt = j(Z, n.draggable), U("drop", this, {evt: t}), $ = Z && Z.parentNode, rt = j(Z), lt = j(Z, n.draggable), jt.eventCanceled || (_t = Ct = Dt = !1, clearInterval(this._loopId), clearTimeout(this._dragStartTimer), zt(this.cloneId), zt(this._dragStartId), this.nativeDraggable && (p(document, "drop", this), p(e, "dragstart", this._onDragStart)), this._offMoveEvents(), this._offUpEvents(), u && R(document.body, "user-select", ""), R(Z, "transform", ""), t && (mt && (t.cancelable && t.preventDefault(), n.dropBubble || t.stopPropagation()), Q && Q.parentNode && Q.parentNode.removeChild(Q), (J === $ || ct && "clone" !== ct.lastPutMode) && nt && nt.parentNode && nt.parentNode.removeChild(nt), Z && (this.nativeDraggable && p(Z, "dragend", this), Lt(Z), Z.style["will-change"] = "", mt && !Dt && k(Z, (ct || this).options.ghostClass, !1), k(Z, this.options.chosenClass, !1), V({
+                sortable: this,
+                name: "unchoose",
+                toEl: $,
+                newIndex: null,
+                newDraggableIndex: null,
+                originalEvent: t
+            }), J !== $ ? (0 <= rt && (V({
+                rootEl: $,
+                name: "add",
+                toEl: $,
+                fromEl: J,
+                originalEvent: t
+            }), V({sortable: this, name: "remove", toEl: $, originalEvent: t}), V({
+                rootEl: $,
+                name: "sort",
+                toEl: $,
+                fromEl: J,
+                originalEvent: t
+            }), V({
+                sortable: this,
+                name: "sort",
+                toEl: $,
+                originalEvent: t
+            })), ct && ct.save()) : rt !== it && 0 <= rt && (V({
+                sortable: this,
+                name: "update",
+                toEl: $,
+                originalEvent: t
+            }), V({
+                sortable: this,
+                name: "sort",
+                toEl: $,
+                originalEvent: t
+            })), jt.active && (null != rt && -1 !== rt || (rt = it, lt = at), V({
+                sortable: this,
+                name: "end",
+                toEl: $,
+                originalEvent: t
+            }), this.save())))), this._nulling()
+        }, _nulling: function () {
+            U("nulling", this), J = Z = $ = Q = tt = nt = et = ot = ut = dt = mt = rt = lt = it = at = vt = bt = ct = st = jt.dragged = jt.ghost = jt.clone = jt.active = null, Ot.forEach(function (t) {
+                t.checked = !0
+            }), Ot.length = ht = pt = 0
+        }, handleEvent: function (t) {
+            switch (t.type) {
+                case"drop":
+                case"dragend":
+                    this._onDrop(t);
+                    break;
+                case"dragenter":
+                case"dragover":
+                    Z && (this._onDragOver(t), function (t) {
+                        t.dataTransfer && (t.dataTransfer.dropEffect = "move");
+                        t.cancelable && t.preventDefault()
+                    }(t));
+                    break;
+                case"selectstart":
+                    t.preventDefault()
+            }
+        }, toArray: function () {
+            for (var t, e = [], n = this.el.children, o = 0, i = n.length, r = this.options; o < i; o++) P(t = n[o], r.draggable, this.el, !1) && e.push(t.getAttribute(r.dataIdAttr) || function (t) {
+                var e = t.tagName + t.className + t.src + t.href + t.textContent, n = e.length, o = 0;
+                for (; n--;) o += e.charCodeAt(n);
+                return o.toString(36)
+            }(t));
+            return e
+        }, sort: function (t, e) {
+            var n = {}, o = this.el;
+            this.toArray().forEach(function (t, e) {
+                e = o.children[e];
+                P(e, this.options.draggable, o, !1) && (n[t] = e)
+            }, this), e && this.captureAnimationState(), t.forEach(function (t) {
+                n[t] && (o.removeChild(n[t]), o.appendChild(n[t]))
+            }), e && this.animateAll()
+        }, save: function () {
+            var t = this.options.store;
+            t && t.set && t.set(this)
+        }, closest: function (t, e) {
+            return P(t, e || this.options.draggable, this.el, !1)
+        }, option: function (t, e) {
+            var n = this.options;
+            if (void 0 === e) return n[t];
+            var o = z.modifyOption(this, t, e);
+            n[t] = void 0 !== o ? o : e, "group" === t && Rt(n)
+        }, destroy: function () {
+            U("destroy", this);
+            var t = this.el;
+            t[K] = null, p(t, "mousedown", this._onTapStart), p(t, "touchstart", this._onTapStart), p(t, "pointerdown", this._onTapStart), this.nativeDraggable && (p(t, "dragover", this), p(t, "dragenter", this)), Array.prototype.forEach.call(t.querySelectorAll("[draggable]"), function (t) {
+                t.removeAttribute("draggable")
+            }), this._onDrop(), this._disableDelayedDragEvents(), St.splice(St.indexOf(this.el), 1), this.el = t = null
+        }, _hideClone: function () {
+            ot || (U("hideClone", this), jt.eventCanceled || (R(nt, "display", "none"), this.options.removeCloneOnHide && nt.parentNode && nt.parentNode.removeChild(nt), ot = !0))
+        }, _showClone: function (t) {
+            "clone" === t.lastPutMode ? ot && (U("showClone", this), jt.eventCanceled || (Z.parentNode != J || this.options.group.revertClone ? tt ? J.insertBefore(nt, tt) : J.appendChild(nt) : J.insertBefore(nt, Z), this.options.group.revertClone && this.animate(Z, nt), R(nt, "display", ""), ot = !1)) : this._hideClone()
+        }
+    }, Mt && h(document, "touchmove", function (t) {
+        (jt.active || Dt) && t.cancelable && t.preventDefault()
+    }), jt.utils = {
+        on: h,
+        off: p,
+        css: R,
+        find: D,
+        is: function (t, e) {
+            return !!P(t, e, t, !1)
+        },
+        extend: function (t, e) {
+            if (t && e) for (var n in e) e.hasOwnProperty(n) && (t[n] = e[n]);
+            return t
+        },
+        throttle: _,
+        closest: P,
+        toggleClass: k,
+        clone: C,
+        index: j,
+        nextTick: Wt,
+        cancelNextTick: zt,
+        detectDirection: kt,
+        getChild: B,
+        expando: K
+    }, jt.get = function (t) {
+        return t[K]
+    }, jt.mount = function () {
+        for (var t = arguments.length, e = new Array(t), n = 0; n < t; n++) e[n] = arguments[n];
+        (e = e[0].constructor === Array ? e[0] : e).forEach(function (t) {
+            if (!t.prototype || !t.prototype.constructor) throw "Sortable: Mounted plugin must be a constructor function, not ".concat({}.toString.call(t));
+            t.utils && (jt.utils = I(I({}, jt.utils), t.utils)), z.mount(t)
+        })
+    }, jt.create = function (t, e) {
+        return new jt(t, e)
+    };
+    var Gt, Ut, qt, Vt, Zt, $t, Qt = [], Jt = !(jt.version = "1.15.6");
+
+    function te() {
+        Qt.forEach(function (t) {
+            clearInterval(t.pid)
+        }), Qt = []
+    }
+
+    function ee() {
+        clearInterval($t)
+    }
+
+    var ne, oe = _(function (n, t, e, o) {
+        if (t.scroll) {
+            var i, r = (n.touches ? n.touches[0] : n).clientX, a = (n.touches ? n.touches[0] : n).clientY,
+                l = t.scrollSensitivity, s = t.scrollSpeed, c = O(), u = !1;
+            Ut !== e && (Ut = e, te(), Gt = t.scroll, i = t.scrollFn, !0 === Gt && (Gt = M(e, !0)));
+            var d = 0, h = Gt;
+            do {
+                var p = h, f = X(p), g = f.top, m = f.bottom, v = f.left, b = f.right, y = f.width, w = f.height,
+                    D = void 0, E = void 0, S = p.scrollWidth, _ = p.scrollHeight, C = R(p), T = p.scrollLeft,
+                    f = p.scrollTop,
+                    E = p === c ? (D = y < S && ("auto" === C.overflowX || "scroll" === C.overflowX || "visible" === C.overflowX), w < _ && ("auto" === C.overflowY || "scroll" === C.overflowY || "visible" === C.overflowY)) : (D = y < S && ("auto" === C.overflowX || "scroll" === C.overflowX), w < _ && ("auto" === C.overflowY || "scroll" === C.overflowY)),
+                    T = D && (Math.abs(b - r) <= l && T + y < S) - (Math.abs(v - r) <= l && !!T),
+                    f = E && (Math.abs(m - a) <= l && f + w < _) - (Math.abs(g - a) <= l && !!f);
+                if (!Qt[d]) for (var x = 0; x <= d; x++) Qt[x] || (Qt[x] = {});
+                Qt[d].vx == T && Qt[d].vy == f && Qt[d].el === p || (Qt[d].el = p, Qt[d].vx = T, Qt[d].vy = f, clearInterval(Qt[d].pid), 0 == T && 0 == f || (u = !0, Qt[d].pid = setInterval(function () {
+                    o && 0 === this.layer && jt.active._onTouchMove(Zt);
+                    var t = Qt[this.layer].vy ? Qt[this.layer].vy * s : 0,
+                        e = Qt[this.layer].vx ? Qt[this.layer].vx * s : 0;
+                    "function" == typeof i && "continue" !== i.call(jt.dragged.parentNode[K], e, t, n, Zt, Qt[this.layer].el) || H(Qt[this.layer].el, e, t)
+                }.bind({layer: d}), 24))), d++
+            } while (t.bubbleScroll && h !== c && (h = M(h, !1)));
+            Jt = u
+        }
+    }, 30), n = function (t) {
+        var e = t.originalEvent, n = t.putSortable, o = t.dragEl, i = t.activeSortable, r = t.dispatchSortableEvent,
+            a = t.hideGhostForTarget, t = t.unhideGhostForTarget;
+        e && (i = n || i, a(), e = e.changedTouches && e.changedTouches.length ? e.changedTouches[0] : e, e = document.elementFromPoint(e.clientX, e.clientY), t(), i && !i.el.contains(e) && (r("spill"), this.onSpill({
+            dragEl: o,
+            putSortable: n
+        })))
+    };
+
+    function ie() {
+    }
+
+    function re() {
+    }
+
+    ie.prototype = {
+        startIndex: null, dragStart: function (t) {
+            t = t.oldDraggableIndex;
+            this.startIndex = t
+        }, onSpill: function (t) {
+            var e = t.dragEl, n = t.putSortable;
+            this.sortable.captureAnimationState(), n && n.captureAnimationState();
+            t = B(this.sortable.el, this.startIndex, this.options);
+            t ? this.sortable.el.insertBefore(e, t) : this.sortable.el.appendChild(e), this.sortable.animateAll(), n && n.animateAll()
+        }, drop: n
+    }, a(ie, {pluginName: "revertOnSpill"}), re.prototype = {
+        onSpill: function (t) {
+            var e = t.dragEl, t = t.putSortable || this.sortable;
+            t.captureAnimationState(), e.parentNode && e.parentNode.removeChild(e), t.animateAll()
+        }, drop: n
+    }, a(re, {pluginName: "removeOnSpill"});
+    var ae, le, se, ce, ue, de = [], he = [], pe = !1, fe = !1, ge = !1;
+
+    function me(n, o) {
+        he.forEach(function (t, e) {
+            e = o.children[t.sortableIndex + (n ? Number(e) : 0)];
+            e ? o.insertBefore(t, e) : o.appendChild(t)
+        })
+    }
+
+    function ve() {
+        de.forEach(function (t) {
+            t !== se && t.parentNode && t.parentNode.removeChild(t)
+        })
+    }
+
+    return jt.mount(new function () {
+        function t() {
+            for (var t in this.defaults = {
+                scroll: !0,
+                forceAutoScrollFallback: !1,
+                scrollSensitivity: 30,
+                scrollSpeed: 10,
+                bubbleScroll: !0
+            }, this) "_" === t.charAt(0) && "function" == typeof this[t] && (this[t] = this[t].bind(this))
+        }
+
+        return t.prototype = {
+            dragStarted: function (t) {
+                t = t.originalEvent;
+                this.sortable.nativeDraggable ? h(document, "dragover", this._handleAutoScroll) : this.options.supportPointer ? h(document, "pointermove", this._handleFallbackAutoScroll) : t.touches ? h(document, "touchmove", this._handleFallbackAutoScroll) : h(document, "mousemove", this._handleFallbackAutoScroll)
+            }, dragOverCompleted: function (t) {
+                t = t.originalEvent;
+                this.options.dragOverBubble || t.rootEl || this._handleAutoScroll(t)
+            }, drop: function () {
+                this.sortable.nativeDraggable ? p(document, "dragover", this._handleAutoScroll) : (p(document, "pointermove", this._handleFallbackAutoScroll), p(document, "touchmove", this._handleFallbackAutoScroll), p(document, "mousemove", this._handleFallbackAutoScroll)), ee(), te(), clearTimeout(m), m = void 0
+            }, nulling: function () {
+                Zt = Ut = Gt = Jt = $t = qt = Vt = null, Qt.length = 0
+            }, _handleFallbackAutoScroll: function (t) {
+                this._handleAutoScroll(t, !0)
+            }, _handleAutoScroll: function (e, n) {
+                var o, i = this, r = (e.touches ? e.touches[0] : e).clientX, a = (e.touches ? e.touches[0] : e).clientY,
+                    t = document.elementFromPoint(r, a);
+                Zt = e, n || this.options.forceAutoScrollFallback || w || y || u ? (oe(e, this.options, t, n), o = M(t, !0), !Jt || $t && r === qt && a === Vt || ($t && ee(), $t = setInterval(function () {
+                    var t = M(document.elementFromPoint(r, a), !0);
+                    t !== o && (o = t, te()), oe(e, i.options, t, n)
+                }, 10), qt = r, Vt = a)) : this.options.bubbleScroll && M(t, !0) !== O() ? oe(e, this.options, M(t, !1), !1) : te()
+            }
+        }, a(t, {pluginName: "scroll", initializeByDefault: !0})
+    }), jt.mount(re, ie), jt.mount(new function () {
+        function t() {
+            this.defaults = {swapClass: "sortable-swap-highlight"}
+        }
+
+        return t.prototype = {
+            dragStart: function (t) {
+                t = t.dragEl;
+                ne = t
+            }, dragOverValid: function (t) {
+                var e = t.completed, n = t.target, o = t.onMove, i = t.activeSortable, r = t.changed, a = t.cancel;
+                i.options.swap && (t = this.sortable.el, i = this.options, n && n !== t && (t = ne, ne = !1 !== o(n) ? (k(n, i.swapClass, !0), n) : null, t && t !== ne && k(t, i.swapClass, !1)), r(), e(!0), a())
+            }, drop: function (t) {
+                var e, n, o = t.activeSortable, i = t.putSortable, r = t.dragEl, a = i || this.sortable,
+                    l = this.options;
+                ne && k(ne, l.swapClass, !1), ne && (l.swap || i && i.options.swap) && r !== ne && (a.captureAnimationState(), a !== o && o.captureAnimationState(), n = ne, t = (e = r).parentNode, l = n.parentNode, t && l && !t.isEqualNode(n) && !l.isEqualNode(e) && (i = j(e), r = j(n), t.isEqualNode(l) && i < r && r++, t.insertBefore(n, t.children[i]), l.insertBefore(e, l.children[r])), a.animateAll(), a !== o && o.animateAll())
+            }, nulling: function () {
+                ne = null
+            }
+        }, a(t, {
+            pluginName: "swap", eventProperties: function () {
+                return {swapItem: ne}
+            }
+        })
+    }), jt.mount(new function () {
+        function t(o) {
+            for (var t in this) "_" === t.charAt(0) && "function" == typeof this[t] && (this[t] = this[t].bind(this));
+            o.options.avoidImplicitDeselect || (o.options.supportPointer ? h(document, "pointerup", this._deselectMultiDrag) : (h(document, "mouseup", this._deselectMultiDrag), h(document, "touchend", this._deselectMultiDrag))), h(document, "keydown", this._checkKeyDown), h(document, "keyup", this._checkKeyUp), this.defaults = {
+                selectedClass: "sortable-selected",
+                multiDragKey: null,
+                avoidImplicitDeselect: !1,
+                setData: function (t, e) {
+                    var n = "";
+                    de.length && le === o ? de.forEach(function (t, e) {
+                        n += (e ? ", " : "") + t.textContent
+                    }) : n = e.textContent, t.setData("Text", n)
+                }
+            }
+        }
+
+        return t.prototype = {
+            multiDragKeyDown: !1, isMultiDrag: !1, delayStartGlobal: function (t) {
+                t = t.dragEl;
+                se = t
+            }, delayEnded: function () {
+                this.isMultiDrag = ~de.indexOf(se)
+            }, setupClone: function (t) {
+                var e = t.sortable, t = t.cancel;
+                if (this.isMultiDrag) {
+                    for (var n = 0; n < de.length; n++) he.push(C(de[n])), he[n].sortableIndex = de[n].sortableIndex, he[n].draggable = !1, he[n].style["will-change"] = "", k(he[n], this.options.selectedClass, !1), de[n] === se && k(he[n], this.options.chosenClass, !1);
+                    e._hideClone(), t()
+                }
+            }, clone: function (t) {
+                var e = t.sortable, n = t.rootEl, o = t.dispatchSortableEvent, t = t.cancel;
+                this.isMultiDrag && (this.options.removeCloneOnHide || de.length && le === e && (me(!0, n), o("clone"), t()))
+            }, showClone: function (t) {
+                var e = t.cloneNowShown, n = t.rootEl, t = t.cancel;
+                this.isMultiDrag && (me(!1, n), he.forEach(function (t) {
+                    R(t, "display", "")
+                }), e(), ue = !1, t())
+            }, hideClone: function (t) {
+                var e = this, n = (t.sortable, t.cloneNowHidden), t = t.cancel;
+                this.isMultiDrag && (he.forEach(function (t) {
+                    R(t, "display", "none"), e.options.removeCloneOnHide && t.parentNode && t.parentNode.removeChild(t)
+                }), n(), ue = !0, t())
+            }, dragStartGlobal: function (t) {
+                t.sortable;
+                !this.isMultiDrag && le && le.multiDrag._deselectMultiDrag(), de.forEach(function (t) {
+                    t.sortableIndex = j(t)
+                }), de = de.sort(function (t, e) {
+                    return t.sortableIndex - e.sortableIndex
+                }), ge = !0
+            }, dragStarted: function (t) {
+                var e, n = this, t = t.sortable;
+                this.isMultiDrag && (this.options.sort && (t.captureAnimationState(), this.options.animation && (de.forEach(function (t) {
+                    t !== se && R(t, "position", "absolute")
+                }), e = X(se, !1, !0, !0), de.forEach(function (t) {
+                    t !== se && T(t, e)
+                }), pe = fe = !0)), t.animateAll(function () {
+                    pe = fe = !1, n.options.animation && de.forEach(function (t) {
+                        x(t)
+                    }), n.options.sort && ve()
+                }))
+            }, dragOver: function (t) {
+                var e = t.target, n = t.completed, t = t.cancel;
+                fe && ~de.indexOf(e) && (n(!1), t())
+            }, revert: function (t) {
+                var n, o, e = t.fromSortable, i = t.rootEl, r = t.sortable, a = t.dragRect;
+                1 < de.length && (de.forEach(function (t) {
+                    r.addAnimationState({
+                        target: t,
+                        rect: fe ? X(t) : a
+                    }), x(t), t.fromRect = a, e.removeAnimationState(t)
+                }), fe = !1, n = !this.options.removeCloneOnHide, o = i, de.forEach(function (t, e) {
+                    e = o.children[t.sortableIndex + (n ? Number(e) : 0)];
+                    e ? o.insertBefore(t, e) : o.appendChild(t)
+                }))
+            }, dragOverCompleted: function (t) {
+                var e, n = t.sortable, o = t.isOwner, i = t.insertion, r = t.activeSortable, a = t.parentEl,
+                    l = t.putSortable, t = this.options;
+                i && (o && r._hideClone(), pe = !1, t.animation && 1 < de.length && (fe || !o && !r.options.sort && !l) && (e = X(se, !1, !0, !0), de.forEach(function (t) {
+                    t !== se && (T(t, e), a.appendChild(t))
+                }), fe = !0), o || (fe || ve(), 1 < de.length ? (o = ue, r._showClone(n), r.options.animation && !ue && o && he.forEach(function (t) {
+                    r.addAnimationState({target: t, rect: ce}), t.fromRect = ce, t.thisAnimationDuration = null
+                })) : r._showClone(n)))
+            }, dragOverAnimationCapture: function (t) {
+                var e = t.dragRect, n = t.isOwner, t = t.activeSortable;
+                de.forEach(function (t) {
+                    t.thisAnimationDuration = null
+                }), t.options.animation && !n && t.multiDrag.isMultiDrag && (ce = a({}, e), e = b(se, !0), ce.top -= e.f, ce.left -= e.e)
+            }, dragOverAnimationComplete: function () {
+                fe && (fe = !1, ve())
+            }, drop: function (t) {
+                var o, i, r, a, n, e, l, s = t.originalEvent, c = t.rootEl, u = t.parentEl, d = t.sortable,
+                    h = t.dispatchSortableEvent, p = t.oldIndex, t = t.putSortable, f = t || this.sortable;
+                s && (o = this.options, i = u.children, ge || (o.multiDragKey && !this.multiDragKeyDown && this._deselectMultiDrag(), k(se, o.selectedClass, !~de.indexOf(se)), ~de.indexOf(se) ? (de.splice(de.indexOf(se), 1), ae = null, G({
+                    sortable: d,
+                    rootEl: c,
+                    name: "deselect",
+                    targetEl: se,
+                    originalEvent: s
+                })) : (de.push(se), G({
+                    sortable: d,
+                    rootEl: c,
+                    name: "select",
+                    targetEl: se,
+                    originalEvent: s
+                }), s.shiftKey && ae && d.el.contains(ae) ? (r = j(ae), a = j(se), ~r && ~a && r !== a && function () {
+                    for (var e, t = r < a ? (e = r, a) : (e = a, r + 1), n = o.filter; e < t; e++) ~de.indexOf(i[e]) || P(i[e], o.draggable, u, !1) && (n && ("function" == typeof n ? n.call(d, s, i[e], d) : n.split(",").some(function (t) {
+                        return P(i[e], t.trim(), u, !1)
+                    })) || (k(i[e], o.selectedClass, !0), de.push(i[e]), G({
+                        sortable: d,
+                        rootEl: c,
+                        name: "select",
+                        targetEl: i[e],
+                        originalEvent: s
+                    })))
+                }()) : ae = se, le = f)), ge && this.isMultiDrag && (fe = !1, (u[K].options.sort || u !== c) && 1 < de.length && (n = X(se), e = j(se, ":not(." + this.options.selectedClass + ")"), !pe && o.animation && (se.thisAnimationDuration = null), f.captureAnimationState(), pe || (o.animation && (se.fromRect = n, de.forEach(function (t) {
+                    var e;
+                    t.thisAnimationDuration = null, t !== se && (e = fe ? X(t) : n, t.fromRect = e, f.addAnimationState({
+                        target: t,
+                        rect: e
+                    }))
+                })), ve(), de.forEach(function (t) {
+                    i[e] ? u.insertBefore(t, i[e]) : u.appendChild(t), e++
+                }), p === j(se) && (l = !1, de.forEach(function (t) {
+                    t.sortableIndex !== j(t) && (l = !0)
+                }), l && (h("update"), h("sort")))), de.forEach(function (t) {
+                    x(t)
+                }), f.animateAll()), le = f), (c === u || t && "clone" !== t.lastPutMode) && he.forEach(function (t) {
+                    t.parentNode && t.parentNode.removeChild(t)
+                }))
+            }, nullingGlobal: function () {
+                this.isMultiDrag = ge = !1, he.length = 0
+            }, destroyGlobal: function () {
+                this._deselectMultiDrag(), p(document, "pointerup", this._deselectMultiDrag), p(document, "mouseup", this._deselectMultiDrag), p(document, "touchend", this._deselectMultiDrag), p(document, "keydown", this._checkKeyDown), p(document, "keyup", this._checkKeyUp)
+            }, _deselectMultiDrag: function (t) {
+                if (!(void 0 !== ge && ge || le !== this.sortable || t && P(t.target, this.options.draggable, this.sortable.el, !1) || t && 0 !== t.button)) for (; de.length;) {
+                    var e = de[0];
+                    k(e, this.options.selectedClass, !1), de.shift(), G({
+                        sortable: this.sortable,
+                        rootEl: this.sortable.el,
+                        name: "deselect",
+                        targetEl: e,
+                        originalEvent: t
+                    })
+                }
+            }, _checkKeyDown: function (t) {
+                t.key === this.options.multiDragKey && (this.multiDragKeyDown = !0)
+            }, _checkKeyUp: function (t) {
+                t.key === this.options.multiDragKey && (this.multiDragKeyDown = !1)
+            }
+        }, a(t, {
+            pluginName: "multiDrag", utils: {
+                select: function (t) {
+                    var e = t.parentNode[K];
+                    e && e.options.multiDrag && !~de.indexOf(t) && (le && le !== e && (le.multiDrag._deselectMultiDrag(), le = e), k(t, e.options.selectedClass, !0), de.push(t))
+                }, deselect: function (t) {
+                    var e = t.parentNode[K], n = de.indexOf(t);
+                    e && e.options.multiDrag && ~n && (k(t, e.options.selectedClass, !1), de.splice(n, 1))
+                }
+            }, eventProperties: function () {
+                var n = this, o = [], i = [];
+                return de.forEach(function (t) {
+                    var e;
+                    o.push({
+                        multiDragElement: t,
+                        index: t.sortableIndex
+                    }), e = fe && t !== se ? -1 : fe ? j(t, ":not(." + n.options.selectedClass + ")") : j(t), i.push({
+                        multiDragElement: t,
+                        index: e
+                    })
+                }), {items: r(de), clones: [].concat(he), oldIndicies: o, newIndicies: i}
+            }, optionListeners: {
+                multiDragKey: function (t) {
+                    return "ctrl" === (t = t.toLowerCase()) ? t = "Control" : 1 < t.length && (t = t.charAt(0).toUpperCase() + t.substr(1)), t
+                }
+            }
+        })
+    }), jt
+});

--- a/style.css
+++ b/style.css
@@ -1814,7 +1814,7 @@ body #bookmarkButton.bookmark-button.rotate {
 }
 
 .theme-transition .search-engine input[type="radio"] {
-	transition: 0.2s;
+	transition: background-color 0.2s ease, border 0.2s ease;
 }
 
 /* -----------end of Radio Button Customizing------------ */

--- a/style.css
+++ b/style.css
@@ -1789,7 +1789,7 @@ body #bookmarkButton.bookmark-button.rotate {
 }
 
 .searchEnginesContainer .search-engine label {
-	margin: 0 16px 0 10px;
+	margin: 0 15px 0 10px;
 	cursor: pointer;
 }
 
@@ -1799,12 +1799,12 @@ body #bookmarkButton.bookmark-button.rotate {
 	-webkit-appearance: none;
 	-moz-appearance: none;
 	background-color: var(--whitishColor-blue);
-	width: 16px;
-	height: 16px;
+	width: 19px;
+	height: 19px;
 	border-radius: 50%;
 	border: 2px solid var(--whitishColor-blue);
 	outline: none;
-	margin-right: 8px;
+	margin-right: 7px;
 	cursor: pointer;
 	/* transition: 0.2s; */
 }

--- a/style.css
+++ b/style.css
@@ -1869,23 +1869,21 @@ body #bookmarkButton.bookmark-button.rotate {
 }
 
 .shortcutsContainer {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(25px, 1fr)); /* Adjust size as needed */
 	pointer-events: auto;
 	transition: transform 0.5s;
 	margin-top: calc(var(--gap) - var(--shortcut-bar-gap-and-padding));
-	max-width: calc(
-		var(--max-shortcut-bar-width) -
-			mod(
-				var(--max-shortcut-bar-width) - var(--shortcut-bar-gap-and-padding),
-				var(--shortcut-size) + var(--shortcut-bar-gap-and-padding)
-			)
-	);
-	display: flex;
-	flex-wrap: wrap;
+	max-width: var(--max-shortcut-bar-width);
 	padding: var(--shortcut-bar-gap-and-padding);
-	justify-content: center;
 	width: fit-content;
-	/* gap: var(--gap) var(--shortcut-bar-gap-and-padding); */
-	gap: 2rem;
+	gap: 1rem;
+	justify-content: center; /* Center if fewer than 10 */
+}
+
+/* Hide elements beyond the first 10 */
+.shortcutsContainer > *:nth-child(n+11) {
+	display: none !important;
 }
 
 .shortcutsContainer::before {
@@ -2450,8 +2448,20 @@ input:checked + .toggle:before {
 #newShortcutButton {
 	fill: var(--textColorDark-blue);
 	border: none;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 	background: none;
 	cursor: pointer;
+}
+
+.rotate-animation {
+	animation: rotate-button 0.5s ease;
+}
+
+@keyframes rotate-button {
+	from { transform: rotate(0deg); }
+	to { transform: rotate(-360deg); }
 }
 
 #newShortcutButton svg {
@@ -2487,10 +2497,21 @@ input:checked + .toggle:before {
 	font-style: italic;
 }
 
+.shortcut-drag{
+	height: 70px;
+	width: 70px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	cursor: grab;
+}
+
 .shortcutSettingsEntry {
+	overflow: hidden;
 	width: 100%;
 	display: flex;
 	height: 68px;
+	gap: 1rem;
 	justify-content: space-between;
 	align-items: center;
 	margin-bottom: 16px;

--- a/style.css
+++ b/style.css
@@ -1799,8 +1799,8 @@ body #bookmarkButton.bookmark-button.rotate {
 	-webkit-appearance: none;
 	-moz-appearance: none;
 	background-color: var(--whitishColor-blue);
-	width: 22px;
-	height: 22px;
+	width: 16px;
+	height: 16px;
 	border-radius: 50%;
 	border: 2px solid var(--whitishColor-blue);
 	outline: none;

--- a/style.css
+++ b/style.css
@@ -1877,7 +1877,7 @@ body #bookmarkButton.bookmark-button.rotate {
 	max-width: var(--max-shortcut-bar-width);
 	padding: var(--shortcut-bar-gap-and-padding);
 	width: fit-content;
-	gap: 1rem;
+	gap: 30px;
 	justify-content: center; /* Center if fewer than 10 */
 }
 


### PR DESCRIPTION
## 📝 Description

- Added the ability to rearrange shortcuts on both the homepage and settings page.
- Implemented drag-and-drop functionality using SortableJS for a smooth user experience.
- Ensured changes persist after reordering in local storage.
- Added migration functionality to migrate custom shortcuts from older version.

## 📸 Screenshots / 📹 Videos

Video File is too large to add here. You can test out the page hosted from my fork: [Preview](https://vchib1.github.io/materialYouNewTab/)

## 🔗 Related Issues
- Closes #<issue_number>
- Related to #<issue_number> (optional)

## ✅ Checklist
- [x] I have read and followed the [Contributing Guidelines](https://github.com/XengShi/materialYouNewTab/blob/main/CONTRIBUTING.md).
- [x] I have tested my changes by installing them as an extension (not just running via localhost) to ensure it builds, installs, and works as expected.
- [x] I have tested these changes in at least Chrome and Firefox (other browsers if applicable).
- [ ] Attached visual evidence of changes (screenshots or videos) if applicable.
