### PR TITLE
Fix Fahrenheit Display

### DIFF
--- a/scripts/weather.js
+++ b/scripts/weather.js
@@ -345,20 +345,17 @@ async function getWeatherData() {
     }
 }
 
-
 // Save and load toggle state
-document.addEventListener("DOMContentLoaded", function () {
-    const hideWeatherCard = document.getElementById("hideWeatherCard");
-    const fahrenheitCheckbox = document.getElementById("fahrenheitCheckbox");
+const hideWeatherCard = document.getElementById("hideWeatherCard");
+const fahrenheitCheckbox = document.getElementById("fahrenheitCheckbox");
 
-    hideWeatherCard.addEventListener("change", function () {
-        saveCheckboxState("hideWeatherCardState", hideWeatherCard);
-    });
-
-    fahrenheitCheckbox.addEventListener("change", function () {
-        saveCheckboxState("fahrenheitCheckboxState", fahrenheitCheckbox);
-    });
-
-    loadCheckboxState("hideWeatherCardState", hideWeatherCard);
-    loadCheckboxState("fahrenheitCheckboxState", fahrenheitCheckbox);
+hideWeatherCard.addEventListener("change", function () {
+    saveCheckboxState("hideWeatherCardState", hideWeatherCard);
 });
+
+fahrenheitCheckbox.addEventListener("change", function () {
+    saveCheckboxState("fahrenheitCheckboxState", fahrenheitCheckbox);
+});
+
+loadCheckboxState("hideWeatherCardState", hideWeatherCard);
+loadCheckboxState("fahrenheitCheckboxState", fahrenheitCheckbox);


### PR DESCRIPTION
fahrenheitCheckbox state was being read later than the weather data display.

Removed document.addEventListener("DOMContentLoaded", function ()
