### PR TITLE
Limit language selector to 6 options

### DIFF
--- a/index.html
+++ b/index.html
@@ -1598,7 +1598,7 @@
                         </div>
 
                         <!-- LANGUAGE SELECTION OPTIONS -->
-                        <select class="languageSelector" id="languageSelector">
+                        <select class="languageSelector" id="languageSelector" size="1">
                             <option value="en">English</option>
                             <option value="az">Azerbaijani (Azərbaycanca)</option>
                             <option value="bn">Bangla (বাংলা)</option>

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -260,6 +260,22 @@ function ApplyLoadingColor() {
 }
 
 
+// Limit language selector to 6 options
+const languageSelector = document.getElementById("languageSelector");
+
+languageSelector.addEventListener("focus", () => {
+    languageSelector.size = 6;
+});
+
+languageSelector.addEventListener("blur", () => {
+    languageSelector.size = 0;
+});
+
+languageSelector.addEventListener("change", () => {
+    languageSelector.size = 1;
+    languageSelector.blur();
+});
+
 // ------------------------------------ Tips ------------------------------------
 document.addEventListener("DOMContentLoaded", function () {
     // Hide tips that are not relevant to mobile
@@ -309,4 +325,3 @@ document.addEventListener("DOMContentLoaded", function () {
         localStorage.setItem("hideTips", "true"); // Save preference
     });
 });
-

--- a/style.css
+++ b/style.css
@@ -2929,17 +2929,6 @@ input:checked + .toggle:before {
 
 /* ---------------Menu-bar-css---------------- */
 
-/* --------------Theming stuff------------------ */
-.themingStuff {
-	margin-top: 11px;
-	position: relative;
-	width: 100%;
-	height: 50px;
-	display: flex;
-	justify-content: space-between;
-	gap: var(--gap);
-}
-
 .languageSection {
 	width: 100%;
 	height: 50px;
@@ -2954,30 +2943,19 @@ input:checked + .toggle:before {
 	align-items: center;
 	justify-content: center;
 	height: fit-content;
-	/* width: 80%; */
 	width: 240px;
 	border: 2px solid transparent;
-	/* adding transparent border on focus it will be turned to theme color*/
 	display: grid;
-	grid-template-columns: repeat(5, 1fr);
-	/* 5 divs in the first row */
-	grid-auto-rows: auto;
-	grid-gap: 10px;
 	padding: 12px;
 	color: var(--textColorDark-blue);
-	/* padding-right: 0px; */
 	border-radius: 26px;
 	appearance: none;
-	/* Remove default browser styles */
 	-webkit-appearance: none;
-	/* For Safari */
 	-moz-appearance: none;
-	/* For Firefox */
 	cursor: pointer;
 	padding-left: 13px;
-
+	/* Scrollbar styles for Firefox */
 	@-moz-document url-prefix() {
-		/* Scrollbar styles for Firefox */
 		scrollbar-width: thin;
 		scrollbar-color: var(--darkColor-blue) transparent;
 	}
@@ -2990,6 +2968,7 @@ input:checked + .toggle:before {
 
 .languageSelector::-webkit-scrollbar-track {
 	background-color: transparent;
+	margin: 6px 0;
 }
 
 .languageSelector::-webkit-scrollbar-thumb {
@@ -2998,10 +2977,39 @@ input:checked + .toggle:before {
 }
 
 .languageSelector:focus {
+	z-index: 1;
 	border: 2px solid var(--darkColor-blue);
-	/* color matching border on focus */
 	outline: none;
-	/* Removes the default outline */
+	padding: 0;
+	border-radius: 16px;
+}
+
+.languageSection select option {
+	font-size: 0.8rem;
+	padding: 10px 15px;
+	border-radius: 10px;
+}
+
+.languageSection select option:hover {
+	background-color: color-mix(in srgb, var(--darkColor-blue) 95%, transparent);
+	color: white;
+}
+
+.languageSection select option:checked {
+	box-shadow: 0 0 10px 100px var(--darkColor-blue) inset;
+	/* bg color not working in edge, so the box-shadow is also used */
+	background-color: var(--darkColor-blue);
+}
+
+/* --------------Theming stuff------------------ */
+.themingStuff {
+	margin-top: 11px;
+	position: relative;
+	width: 100%;
+	height: 50px;
+	display: flex;
+	justify-content: space-between;
+	gap: var(--gap);
 }
 
 .colorsContainer {
@@ -3010,14 +3018,12 @@ input:checked + .toggle:before {
 	justify-content: center;
 	height: fit-content;
 	width: fit-content;
-
 	display: grid;
 	grid-template-columns: repeat(5, 1fr);
 	/* 5 divs in the first row */
 	grid-auto-rows: auto;
 	grid-gap: 10px;
 	padding: 10px;
-	/* padding-right: 0px; */
 	border-radius: 26px;
 }
 
@@ -3030,7 +3036,6 @@ input:checked + .toggle:before {
 	width: 36px;
 	border-radius: 18px;
 	outline: none;
-	/* margin-right: 10px; */
 	cursor: pointer;
 }
 


### PR DESCRIPTION
## 📌 Description
Limited language selector to 6 options
Not used custom dropdown but make it  behaves like a listbox instead of dropdown

(todo: dark theme colors)

Tested on Chrome, Firefox, Edge, Brave

Issue:
- In firefox, when expanded dropdown briefly flashes with default style and there is a dash outline/border on selected option.

Limitation:
- Keyboard support: arrow up/down or aan alphabet key triggers the option, no navigation

## 🎨 Visual Changes (Screenshots / Videos)
Live: https://tyy69r.csb.app/

![image](https://github.com/user-attachments/assets/07b86661-9e24-4410-8e5f-2899bbbf3920)

## 🔗 Related Issues
- Closes #184
- Related to #275

## ✅ Checklist
- [ ] I have read and followed the [Contributing Guidelines](https://github.com/XengShi/materialYouNewTab/blob/main/CONTRIBUTING.md).
- [ ] I have tested my changes thoroughly to ensure expected behavior.
- [ ] I have verified compatibility across Chrome and Firefox (additional browsers if applicable).
- [ ] I have attached relevant visual evidence (screenshots/videos) if applicable.
- [ ] My code follows the project's coding style and conventions.
- [ ] I have updated the [CHANGELOG.md](https://github.com/XengShi/materialYouNewTab/blob/main/CHANGELOG.md) under the appropriate categories with all my changes in this PR.
